### PR TITLE
[Feat] 프레임 데이터 저장 및 불러오기 기능 추가 (#12)

### DIFF
--- a/include/Utils.h
+++ b/include/Utils.h
@@ -1,0 +1,31 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+#include <string>
+#include <opencv2/opencv.hpp>
+
+class Utils {
+public:
+    Utils(const std::string& saveDirectory = "./frames");
+
+    bool saveFrame(const cv::Mat& frame, const std::string& path, const std::string& name);
+
+    bool saveFrameToCurrentFrameFolder(const cv::Mat& frame, const std::string& name);
+
+    bool saveFrameToSleepinessFolder(const cv::Mat& frame, const std::string& name);
+
+    bool removeFolder(const std::string& path);
+
+    std::vector<cv::Mat> loadFramesFromRecentFolder();
+
+    std::vector<cv::Mat> loadFramesFromFolder(const std::string& folderPath);
+
+    std::string createSleepinessDir(const std::string& timeStamp);
+
+private:
+    std::string saveDirectory;
+    std::string recentFolder;
+    std::string sleepFolder;
+};
+
+#endif

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1,0 +1,89 @@
+#include "../include/Utils.h"
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+
+Utils::Utils(const std::string& saveDirectory) 
+    : saveDirectory(saveDirectory), recentFolder("/recent"), sleepFolder("")
+{
+    if (!std::filesystem::exists(saveDirectory)) {
+        std::filesystem::create_directories(saveDirectory);
+    }
+
+    if (!std::filesystem::exists(saveDirectory+recentFolder)) {
+        std::filesystem::create_directories(saveDirectory+recentFolder);
+    }
+}
+
+bool Utils::saveFrame(const cv::Mat& frame, const std::string& path, const std::string& name) {
+    if (frame.empty()) {
+        std::cerr << "Error: Empty frame, cannot save." << std::endl;
+        return false;
+    }
+
+    if (!std::filesystem::exists(path)) {
+        std::filesystem::create_directories(path);
+    }
+    return cv::imwrite(path+"/"+name, frame);
+}
+
+bool Utils::saveFrameToCurrentFrameFolder(const cv::Mat& frame, const std::string& name){
+    if(sleepFolder.size() == 0) return false;
+    return saveFrame(frame, saveDirectory+sleepFolder, name);
+}
+
+bool Utils::saveFrameToSleepinessFolder(const cv::Mat& frame, const std::string& name){
+    return saveFrame(frame, saveDirectory+recentFolder, name);
+}
+
+bool Utils::removeFolder(const std::string& folderName){
+    std::string folderPath = saveDirectory + "/" + folderName;
+    try {
+        if (fs::exists(folderPath) && fs::is_directory(folderPath)) {
+            return fs::remove_all(folderPath) > 0;
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "Error removing folder: " << e.what() << std::endl;
+    }
+    return false;
+}
+
+std::vector<cv::Mat> Utils::loadFramesFromFolder(const std::string& folderName){
+    std::vector<cv::Mat> frames;
+    std::vector<std::filesystem::directory_entry> entries;
+    for (const auto& entry : std::filesystem::directory_iterator(saveDirectory+"/"+folderName)) {
+        if (entry.path().extension() == ".jpg" || entry.path().extension() == ".png") {
+            entries.push_back(entry);
+        }
+    }
+    std::sort(entries.begin(), entries.end(), [](const auto& a, const auto& b) {
+        return a.path().string() < b.path().string();
+    });
+    for (const auto& entry : entries) {
+        cv::Mat img = cv::imread(entry.path().string());
+        if (!img.empty()) {
+            frames.push_back(img);
+        }
+    }
+
+    return frames;
+}
+
+std::vector<cv::Mat> Utils::loadFramesFromRecentFolder() {
+    return loadFramesFromFolder(recentFolder);
+}
+
+std::string Utils::createSleepinessDir(const std::string& timeStamp){
+    std::string path = "/"+timeStamp;
+    if (!std::filesystem::exists(saveDirectory+path)) {
+        std::filesystem::create_directories(saveDirectory+path);
+    }
+
+    this->sleepFolder = path;
+    return path;
+}

--- a/test/UtilsTest.cpp
+++ b/test/UtilsTest.cpp
@@ -1,0 +1,18 @@
+#include "../include/Utils.h"
+
+int main() {
+
+	Utils test;
+	std::vector<cv::Mat> data = test.loadFramesFromRecentFolder();
+
+	std::string path = test.createSleepinessDir("test1234");
+	int count = 0;
+	for each (cv::Mat var in data)
+	{
+		std::string name = std::to_string(count++) + ".jpg";
+		test.saveFrameToSleepinessFolder(var, name);
+		test.saveFrameToCurrentFrameFolder(var, name);
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

resolved #12 

## 📝 작업 내용

- frame 데이터 저장 함수
  - 현 sleep 폴더
  - recent 폴더
- frame List 불러오기 함수
  - 지정 폴더
  - recent 폴더
- 새 dir 생성 함수
- test

** 프레임 데이터의 파일 이름은 idx 값이라고 생각하고 구현했습니다. frameList 불러오기 시 이름을 통한 정렬이 적용됩니다.
** 새 dir 생성 함수를 통해 현 sleep 폴더 path값이 업데이트 됩니다.

### 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/89439e77-31da-4052-8ece-bd309bec93fd)
![image](https://github.com/user-attachments/assets/e3a52fd4-adb2-4dea-83ef-1d9ea20a5319)

- recent의 있는 img를 불러와서, recent와 특정 path에 저장하는 test 진행
- 확인된 점
  - recent 폴더에서 img가 cv::Mat vector 데이터로 잘 불러와집니다.
  - recent 폴더에서 불러오는 함수는 지정 폴더 불러오기 함수를 이용했기 때문에 이 또한 잘 구현되었음을 알 수 있습니다.
  - 현 sleep 폴더와 recent 폴더에 모두 잘 저장됩니다.

## 💬 리뷰 요청사항 (선택)


