### PR TITLE
[feat] DBThread 백서버 졸음 영상 전송 통신 추가

### DIFF
--- a/include/DBThread.h
+++ b/include/DBThread.h
@@ -22,6 +22,7 @@ public:
     ~DBThread();
     bool sendDataToDB();
     void setIsDBThreadRunningFalse();
+    std::string getDetectedAtFromFolder() const;
 
     const std::string& getDeviceUid() const { return deviceUid; }
     const std::string& getFolderPath() const { return folderPath; }

--- a/include/DBThread.h
+++ b/include/DBThread.h
@@ -21,6 +21,7 @@ public:
     DBThread(const std::string& uid, const std::string& folder, DBThreadMonitoring* monitor);
     ~DBThread();
     bool sendDataToDB();
+    bool sendVideoToBackend(const std::vector<uchar>& videoData);
     void setIsDBThreadRunningFalse();
     std::string getDetectedAtFromFolder() const;
 

--- a/include/DBThread.h
+++ b/include/DBThread.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <filesystem>
 #include <vector>
+#include <opencv2/core.hpp> 
 #include "VideoEncoder.h"
 
 class DBThreadMonitoring;

--- a/src/DBThread.cpp
+++ b/src/DBThread.cpp
@@ -2,11 +2,13 @@
 #include "../include/DBThreadMonitoring.h"
 #include <vector>
 #include <iostream>
+#include <sstream> 
 #include <fstream>
 #include <filesystem>
 #include <thread>
 #include <cpr/cpr.h>
 #include <ctime>
+#include <random>
 
 DBThread::DBThread(const std::string& uid, const std::string& folder, DBThreadMonitoring* monitor)
     : deviceUid(uid), folderPath(folder), monitoring(monitor) {
@@ -96,7 +98,7 @@ bool DBThread::sendVideoToBackend(const std::vector<uchar>& videoData) {
             return false;
         }
 
-        std::string tempVideoPath = (std::filesystem::temp_directory_path() / "temp_video.mp4").string();
+        std::string tempVideoPath = generateTempFilePath();
         std::ofstream outFile(tempVideoPath, std::ios::binary);
         outFile.write(reinterpret_cast<const char*>(videoData.data()), videoData.size());
         outFile.close();
@@ -138,3 +140,22 @@ bool DBThread::sendVideoToBackend(const std::vector<uchar>& videoData) {
 
     return false;
 }
+
+namespace {
+    std::string generateTempFilePath() {
+        std::stringstream ss;
+        ss << std::filesystem::temp_directory_path().string();
+
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_int_distribution<> dis(0, 15);
+        ss << "temp_video_";
+        for (int i = 0; i < 8; ++i) {
+            ss << std::hex << dis(gen);
+        }
+        ss << ".mp4";
+
+        return ss.str();
+    }
+}
+

--- a/src/DBThread.cpp
+++ b/src/DBThread.cpp
@@ -2,8 +2,11 @@
 #include "../include/DBThreadMonitoring.h"
 #include <vector>
 #include <iostream>
+#include <fstream>
 #include <filesystem>
 #include <thread>
+#include <cpr/cpr.h>
+#include <ctime>
 
 DBThread::DBThread(const std::string& uid, const std::string& folder, DBThreadMonitoring* monitor)
     : deviceUid(uid), folderPath(folder), monitoring(monitor) {
@@ -38,8 +41,59 @@ bool DBThread::sendDataToDB() {
 
     while (!backendResponse && attempt < MAX_RETRIES) {
         std::cout << "백엔드 서버 통신 " << (attempt + 1) << " 번째 시도" << std::endl;
-        // TODO: 실제 백엔드 전송 로직 필요
-        backendResponse = true; // 임시로 성공으로 가정
+
+        std::string hash = getenv("EMBEDDED_HASH");
+        std::string deviceUid = getenv("DEVICE_UID");
+        std::string serverIP = getenv("SERVER_IP");
+
+        if (hash.empty() || deviceUid.empty() || serverIP.empty()) {
+            std::cerr << "환경 변수 설정 오류: 통신에 필요한 정보 누락" << std::endl;
+            setIsDBThreadRunningFalse();
+            return false;
+        }
+
+        std::string detectedAt = getDetectedAtFromFolder();
+        if (detectedAt.empty()) {
+            std::cerr << "detectedAt 추출 실패" << std::endl;
+            setIsDBThreadRunningFalse();
+            return false;
+        }
+
+        std::string tempVideoPath = (std::filesystem::temp_directory_path() / "temp_video.mp4").string();
+        std::ofstream outFile(tempVideoPath, std::ios::binary);
+        outFile.write(reinterpret_cast<const char*>(videoData.data()), videoData.size());
+        outFile.close();
+
+        cpr::Header headers = {
+            {"Authorization", "Bearer " + hash},
+            {"Content-Type", "multipart/form-data"}
+        };
+
+        cpr::Multipart multipart{
+            {"deviceUid", deviceUid},
+            {"detectedAt", detectedAt},
+            {"videoFile", cpr::File{tempVideoPath, "video/mp4"}}
+        };
+
+        std::string url = serverIP + "/sleep";
+        cpr::Response r = cpr::Post(cpr::Url{ url }, headers, multipart);
+
+        if (r.status_code == 200 && r.text.find("졸음 감지 데이터가 저장되었습니다.") != std::string::npos) {
+            backendResponse = true;
+        }
+        else {
+            std::cerr << "백엔드 응답 실패 (" << r.status_code << "): " << r.error.message << "\n응답 본문: " << r.text << std::endl;
+        }
+
+
+        try {
+            std::filesystem::remove(tempVideoPath);
+        }
+        catch (const std::exception& e) {
+            std::cerr << "임시 영상 파일 삭제 실패: " << e.what() << std::endl;
+        }
+
+
 
         if (backendResponse) {
             std::cout << "백엔드 영상 저장 성공, 로컬 폴더 삭제 : " << folderPath << std::endl;
@@ -63,3 +117,20 @@ void DBThread::setIsDBThreadRunningFalse() {
         monitoring->setIsDBThreadRunning(false);
     }
 }
+
+std::string DBThread::getDetectedAtFromFolder() const {
+    std::string folderName = std::filesystem::path(folderPath).filename().string();
+    std::tm folderTime = {};
+    std::istringstream ss(folderName);
+    ss >> std::get_time(&folderTime, "%Y%m%d_%H%M%S");
+
+    if (ss.fail()) {
+        std::cerr << "DBThread 폴더 이름에서 타임스탬프를 파싱할 수 없음: " << folderName << std::endl;
+        return "";
+    }
+
+    char timeStr[30];
+    std::strftime(timeStr, sizeof(timeStr), "%Y-%m-%dT%H:%M:%S", &folderTime);
+    return std::string(timeStr);
+}
+

--- a/src/DBThread.cpp
+++ b/src/DBThread.cpp
@@ -102,8 +102,7 @@ bool DBThread::sendVideoToBackend(const std::vector<uchar>& videoData) {
         outFile.close();
 
         cpr::Header headers = {
-            {"Authorization", "Bearer " + hash},
-            {"Content-Type", "multipart/form-data"}
+            {"Authorization", "Bearer " + hash}
         };
 
         cpr::Multipart multipart{

--- a/src/DBThread.cpp
+++ b/src/DBThread.cpp
@@ -9,6 +9,8 @@
 #include <cpr/cpr.h>
 #include <ctime>
 #include <random>
+#include <iomanip>
+#include <chrono>
 
 DBThread::DBThread(const std::string& uid, const std::string& folder, DBThreadMonitoring* monitor)
     : deviceUid(uid), folderPath(folder), monitoring(monitor) {

--- a/src/DBThread.cpp
+++ b/src/DBThread.cpp
@@ -85,14 +85,19 @@ bool DBThread::sendVideoToBackend(const std::vector<uchar>& videoData) {
     while (!backendResponse && attempt < MAX_RETRIES) {
         std::cout << "백엔드 서버 통신 " << (attempt + 1) << " 번째 시도" << std::endl;
 
-        std::string hash = getenv("EMBEDDED_HASH");
-        std::string deviceUidEnv = getenv("DEVICE_UID");
-        std::string serverIP = getenv("SERVER_IP");
+        const char* hashC = std::getenv("EMBEDDED_HASH");
+        const char* uidC = std::getenv("DEVICE_UID");
+        const char* ipC = std::getenv("SERVER_IP");
 
-        if (hash.empty() || deviceUidEnv.empty() || serverIP.empty()) {
+        if (!hashC || !uidC || !ipC) {
             std::cerr << "환경 변수 설정 오류: 통신에 필요한 정보 누락" << std::endl;
             return false;
         }
+
+        std::string hash(hashC);
+        std::string deviceUidEnv(uidC);
+        std::string serverIP(ipC);
+
 
         std::string detectedAt = getDetectedAtFromFolder();
         if (detectedAt.empty()) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 연결해 주세요.  
> closed #20 

## 📝 작업 내용

> 이번 PR에서 어떤 작업을 했는지 간단히 작성해 주세요.

- DBThread에서 folder path 경로 시간을 기준으로 5초 간의 영상 데이터를 deviceUid, timestamp와 함께 백서버에 DB 저장 요청을 보냅니다.

### 📸 스크린샷 (선택)

> UI 변경사항이 있다면 캡처해서 첨부해 주세요.

## 💬 리뷰 요청사항 (선택)

> 리뷰어가 중점적으로 봐줬으면 하는 부분이 있다면 적어 주세요.  
> 예: `메서드 XXX의 네이밍`을 좀 더 의미 있게 바꾸고 싶은데 좋은 아이디어가 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 백엔드로 영상 데이터를 전송하는 기능이 추가되었습니다.
  - 폴더명에서 감지된 시각 정보를 추출하는 기능이 추가되었습니다.

- **버그 수정**
  - 영상 업로드 실패 시 최대 5회 재시도 및 오류 처리 로직이 개선되었습니다.

- **리팩터링**
  - 영상 업로드 및 상태 관리 로직이 구조적으로 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->