### PR TITLE
[Test] window 실행 환경 세팅 (#28)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,103 +1,60 @@
-# CMake 최소 버전 요구. 3.10 이상이어야 이 설정을 인식할 수 있음.
 cmake_minimum_required(VERSION 3.10)
+cmake_policy(SET CMP0148 NEW)
+set(CMAKE_TOOLCHAIN_FILE "C:/Users/twin4/vcpkg/scripts/buildsystems/vcpkg.cmake" CACHE STRING "")
+set(CMAKE_PREFIX_PATH "C:/Users/twin4/vcpkg/installed/x64-windows/share" ${CMAKE_PREFIX_PATH})
 
-# 프로젝트 이름을 설정. 이후 변수 ${PROJECT_NAME}으로도 사용 가능.
+
 project(NoSleepDrive)
 
-# 사용할 C++ 표준 설정 (C++17 사용)
 set(CMAKE_CXX_STANDARD 17)
 
-# OpenCV 패키지를 찾음. 시스템에 설치된 OpenCV를 탐색함.
-# REQUIRED 옵션은 못 찾으면 오류 발생시킴.
+# OpenCV
 find_package(OpenCV REQUIRED)
-
-# OpenCV 헤더 파일 경로를 포함 경로에 추가
 include_directories(${OpenCV_INCLUDE_DIRS})
 
-# Python 라이브러리 찾기 (Python 해더 및 링크 라이브러리)
-find_package(PythonLibs REQUIRED)
+# Python3 + NumPy (CMake 3.12 이상부터 지원, CMake 3.28 호환됨)
+find_package(Python3 COMPONENTS Interpreter Development NumPy REQUIRED)
+include_directories(${Python3_INCLUDE_DIRS} ${Python3_NumPy_INCLUDE_DIRS})
 
-# Python 헤더 파일 경로를 포함 경로에 추가
-include_directories(${PYTHON_INCLUDE_DIRS})
+# NumPy 경로 메시지 출력 (선택 사항)
+message(STATUS "Found Python3 include path: ${Python3_INCLUDE_DIRS}")
+message(STATUS "Found NumPy include path: ${Python3_NumPy_INCLUDE_DIRS}")
 
-# NumPy 헤더 경로를 Python으로 직접 찾기
-execute_process(
-    COMMAND python3 -c "import numpy; print(numpy.get_include())"
-    OUTPUT_VARIABLE NUMPY_INCLUDE_PATH
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+# nlohmann json header
+include_directories(${PROJECT_SOURCE_DIR}/include)
 
-if(NUMPY_INCLUDE_PATH)
-    include_directories(${NUMPY_INCLUDE_PATH})
-    message(STATUS "Found NumPy include path: ${NUMPY_INCLUDE_PATH}")
-else()
-    message(FATAL_ERROR "Could not find NumPy include path")
-endif()
+find_package(cpr CONFIG REQUIRED)
 
-# nlohmann 헤더 파일 경로를 포함 경로에 추가
-include_directories(${PROJECT_SOURCE_DIR}/include) # include 디렉토리에 json.hpp 필요
+find_package(ZLIB REQUIRED)
+include_directories(${ZLIB_INCLUDE_DIRS})
 
-# CPR 라이브러리 찾기 (수동 설정)
-find_library(CPR_LIBRARY
-    NAMES cpr libcpr
-    PATHS /usr/local/lib /usr/lib
-    REQUIRED
-)
 
-find_path(CPR_INCLUDE_DIR
-    NAMES cpr/cpr.h
-    PATHS /usr/local/include /usr/include
-    REQUIRED
-)
-
-# OpenSSL 패키지 찾기 (CPR에서 필요)
+# OpenSSL
 find_package(OpenSSL REQUIRED)
 
-if(CPR_LIBRARY AND CPR_INCLUDE_DIR)
-    message(STATUS "Found CPR library: ${CPR_LIBRARY}")
-    message(STATUS "Found CPR include: ${CPR_INCLUDE_DIR}")
-    include_directories(${CPR_INCLUDE_DIR})
-else()
-    message(FATAL_ERROR "Could not find CPR library")
-endif()
-
-# NumPy 헤더 경로를 Python으로 직접 찾기
-execute_process(
-    COMMAND python3 -c "import numpy; print(numpy.get_include())"
-    OUTPUT_VARIABLE NUMPY_INCLUDE_PATH
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-if(NUMPY_INCLUDE_PATH)
-    include_directories(${NUMPY_INCLUDE_PATH})
-    message(STATUS "Found NumPy include path: ${NUMPY_INCLUDE_PATH}")
-else()
-    message(FATAL_ERROR "Could not find NumPy include path")
-endif()
-
-# src 디렉토리의 모든 .cpp 파일을 자동으로 찾아 SOURCE_FILES 변수에 저장
+# 소스 파일 수집
 file(GLOB_RECURSE SOURCE_FILES src/*.cpp)
 
-# 실행 파일 생성 시 모든 소스 파일 사용
+# 실행 파일 생성
 add_executable(nosleep_drive ${SOURCE_FILES})
 
-# 컴파일러 정의 추가 (NumPy API 관련)
+# NumPy 매크로 정의
 target_compile_definitions(nosleep_drive PRIVATE 
     NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION
 )
 
-# 실행 파일과 외부 라이브러리를 연결
-# OpenCV, Python, CPR, OpenSSL 관련 라이브러리를 함께 링크함
+# 외부 라이브러리 링크
 target_link_libraries(nosleep_drive 
-    ${OpenCV_LIBS} 
-    ${PYTHON_LIBRARIES} 
-    ${CPR_LIBRARY}
+    ${OpenCV_LIBS}
+    ${Python3_LIBRARIES}
+    cpr::cpr
     ${OPENSSL_LIBRARIES}
-    ssl
-    crypto
-    curl
-    pthread
+    ${ZLIB_LIBRARIES}
 )
 
-# 추가 컴파일 옵션
-target_compile_options(nosleep_drive PRIVATE -Wall -Wextra)
+# 컴파일 옵션
+if (MSVC)
+    target_compile_options(nosleep_drive PRIVATE /W4)
+else()
+    target_compile_options(nosleep_drive PRIVATE -Wall -Wextra -Werror)
+endif() 

--- a/include/FirmwareManager.h
+++ b/include/FirmwareManager.h
@@ -48,6 +48,12 @@ private:
 	// 스레드
 	std::thread mainThread;
 
+	// 이전 졸음 상태
+	bool previousSleepy = false;
+
+	// 졸음 진단 폴더 경로 저장 스택 (DB 스레드 모니터링용)
+	std::stack<std::string> sleepImgPathStack;
+
 	// 내부 메서드
 	void mainLoop();
 	bool processSingleFrame();

--- a/include/FirmwareManager.h
+++ b/include/FirmwareManager.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <future>
 
 // Python.h 및 NumPy 헤더 포함
 #include <Python.h>

--- a/include/Speaker.h
+++ b/include/Speaker.h
@@ -11,7 +11,7 @@ private:
 	int volume;
 
 public:
-	Speaker(const std::string& soundFilePath = "./sounds/alert.mp3", int vol = 70);
+	Speaker(const std::string& soundFilePath = "../../../sounds/alert.mp3", int vol = 70);
 	~Speaker();
 
 	void initialize() override;

--- a/include/Utils.h
+++ b/include/Utils.h
@@ -19,18 +19,25 @@ public:
 
     bool saveFrameToSleepinessFolder(const cv::Mat& frame, const std::string& name);
 
+    bool removeSleepinessEvidenceFolder() { return removeFolder(sleepFolder); }
+
     bool removeFolder(const std::string& path);
 
-    std::vector<cv::Mat> loadFramesFromRecentFolder();
+    std::vector<cv::Mat> loadFramesFromRecentFolder(const std::string& timeStamp);
 
-    std::vector<cv::Mat> loadFramesFromFolder(const std::string& folderPath);
+    std::vector<std::pair<std::string, std::string>> getRecentFramePathsAndNames(
+        const std::string& timeStamp);
 
     std::string createSleepinessDir(const std::string& timeStamp);
 
     void loadEnvFile(const std::string& filename);
 
-private:
+    int sleepinessEvidenceCount = 0;
+    const int MAX_SLEEPINESS_EVIDENCE_COUNT = 60;
+    bool IsSavingSleepinessEvidence = false;
     std::string saveDirectory;
+
+private:
     std::string recentFolder;
     std::string sleepFolder;
 };

--- a/include/Utils.h
+++ b/include/Utils.h
@@ -32,8 +32,10 @@ public:
 
     void loadEnvFile(const std::string& filename);
 
+    long long parseFileTimeMillis(const std::string& filename);
+
     int sleepinessEvidenceCount = 0;
-    const int MAX_SLEEPINESS_EVIDENCE_COUNT = 60;
+    const int MAX_SLEEPINESS_EVIDENCE_COUNT = 120;
     bool IsSavingSleepinessEvidence = false;
     std::string saveDirectory;
 

--- a/python/eye_detection_lib.py
+++ b/python/eye_detection_lib.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+import os
 import numpy as np
 import dlib
 import cv2
@@ -27,7 +28,9 @@ def initialize():
     global predictor
     try:
         # Load face landmark model
-        predictor = dlib.shape_predictor("shape_predictor_68_face_landmarks.dat")
+        base_path = os.path.dirname(os.path.abspath(__file__))
+        model_path = os.path.join(base_path, "eye_closed_detection", "shape_predictor_68_face_landmarks.dat")
+        predictor = dlib.shape_predictor(model_path)
         return True
     except Exception as e:
         print(f"[ERROR] Error during initialization: {e}")

--- a/src/AccelerationSensor.cpp
+++ b/src/AccelerationSensor.cpp
@@ -147,7 +147,7 @@ MockAccelerationSensor::MockAccelerationSensor()
 		: xAcceleration(0.0f),
 			yAcceleration(0.0f),
 			zAcceleration(9.8f),
-			moving(false),
+			moving(true),
 			rng(std::chrono::system_clock::now().time_since_epoch().count()),
 			dist(-0.2f, 0.2f) {}
 

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -95,6 +95,10 @@ cv::Mat Camera::captureFrame() {
 }
 
 void Camera::setCameraStatus(bool status) {
+	bool currStatus = getCameraStatus();
+	if (currStatus == status) {
+		return;	 // 상태가 변경되지 않았으면 아무 작업도 하지 않음
+	}
 	updateDeviceStatus(0, status);	// Camera is index 0
 }
 

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -15,11 +15,30 @@ Camera::~Camera() {
 }
 
 void Camera::initialize() {
+#ifdef _WIN32
+	// ✅ Windows: 기본 웹캠 사용 (cv::VideoCapture 인덱스 0)
+	int cameraIndex = 0;
+	cap.open(cameraIndex, cv::CAP_DSHOW); // 또는 CAP_ANY, CAP_MSMF도 가능
+
+	if (!cap.isOpened()) {
+		std::cerr << "Error: Could not open default webcam on Windows." << std::endl;
+		setConnectionStatus(false);
+		updateDeviceStatus(0, false);
+		return;
+	}
+
+	// 해상도 설정
+	cap.set(cv::CAP_PROP_FRAME_WIDTH, resolution[0]);
+	cap.set(cv::CAP_PROP_FRAME_HEIGHT, resolution[1]);
+
+#else
+	// ✅ Linux / Raspberry Pi: GStreamer 파이프라인 사용
+
 	// GStreamer 파이프라인 구성
 	gstreamerPipeline = "libcamerasrc camera-name=" + cameraName +
-											" ! video/x-raw,width=" + std::to_string(resolution[0]) +
-											",height=" + std::to_string(resolution[1]) + ",framerate=10/1,format=RGBx" +
-											" ! videoconvert ! videoscale" + " ! video/x-raw,format=BGR" + " ! appsink";
+		" ! video/x-raw,width=" + std::to_string(resolution[0]) +
+		",height=" + std::to_string(resolution[1]) + ",framerate=10/1,format=RGBx" +
+		" ! videoconvert ! videoscale" + " ! video/x-raw,format=BGR" + " ! appsink";
 
 	// GStreamer 파이프라인으로 카메라 열기
 	cap.open(gstreamerPipeline, cv::CAP_GSTREAMER);
@@ -30,7 +49,9 @@ void Camera::initialize() {
 		setConnectionStatus(false);
 		updateDeviceStatus(0, false);	 // Camera is index 0
 		return;
-	}
+}
+#endif
+
 
 	// 테스트 프레임 캡처
 	cv::Mat testFrame;

--- a/src/DBThread.cpp
+++ b/src/DBThread.cpp
@@ -120,9 +120,13 @@ bool DBThread::sendVideoToBackend(const std::vector<uchar>& videoData) {
 		std::string serverIP(ipC);
 
 		std::string detectedAt = getDetectedAtFromFolder();
+		std::replace(detectedAt.begin(), detectedAt.end(), 'T', ' ');
 		if (detectedAt.empty()) {
 			std::cerr << "detectedAt parsing failed" << std::endl;
 			return false;
+		}
+		if (detectedAt.find('.') == std::string::npos) {
+			detectedAt += ".000000";
 		}
 
 		std::string tempVideoPath = generateTempFilePath();
@@ -134,7 +138,8 @@ bool DBThread::sendVideoToBackend(const std::vector<uchar>& videoData) {
 
 		cpr::Multipart multipart{{"deviceUid", deviceUidEnv},
 														 {"detectedAt", detectedAt},
-														 {"videoFile", cpr::File{tempVideoPath, "video/mp4"}}};
+														{"checksum", "test"},
+														 {"videoFile", cpr::File{tempVideoPath, "video.mp4"}}};
 
 		std::string url = serverIP + "/sleep";
 		cpr::Response r = cpr::Post(cpr::Url{url}, headers, multipart);

--- a/src/DBThread.cpp
+++ b/src/DBThread.cpp
@@ -99,7 +99,7 @@ std::string DBThread::getDetectedAtFromFolder() const {
 
 bool DBThread::sendVideoToBackend(const std::vector<uchar>& videoData) {
 	const int MAX_RETRIES = 5;
-	const int RETRY_DELAY_MS = 1000;
+	const int RETRY_DELAY_MS = 10000;
 	bool backendResponse = false;
 	int attempt = 0;
 
@@ -144,7 +144,7 @@ bool DBThread::sendVideoToBackend(const std::vector<uchar>& videoData) {
 		std::string url = serverIP + "/sleep";
 		cpr::Response r = cpr::Post(cpr::Url{url}, headers, multipart);
 
-		if (r.status_code == 200 &&
+		if (r.status_code == 201 &&
 				r.text.find("sleepiness detection data saved.") != std::string::npos) {
 			backendResponse = true;
 		} else {

--- a/src/DBThread.cpp
+++ b/src/DBThread.cpp
@@ -43,19 +43,19 @@ DBThread::~DBThread() {}
 void DBThread::deleteFolderSafe(const std::string& path) {
 	try {
 		std::filesystem::remove_all(path);
-		std::cout << "[DBThread] 폴더 삭제 성공: " << path << std::endl;
+		//std::cout << "[DBThread] 폴더 삭제 성공: " << path << std::endl;
 	} catch (const std::filesystem::filesystem_error& e) {
-		std::cerr << "[DBThread] 폴더 삭제 실패: " << e.what() << std::endl;
+		//std::cerr << "[DBThread] 폴더 삭제 실패: " << e.what() << std::endl;
 	}
 }
 
 bool DBThread::sendDataToDB() {
 	VideoEncoder encoder;
-	std::cout << "백서버 통신 전 이미지 데이터들을 영상 데이터로 변환" << std::endl;
+	//std::cout << "백서버 통신 전 이미지 데이터들을 영상 데이터로 변환" << std::endl;
 
 	std::vector<uchar> videoData = encoder.convertFramesToMP4(folderPath);
 	if (videoData.empty()) {
-		std::cerr << "영상 생성 실패로 영상 전송 통신 취소." << std::endl;
+		//std::cerr << "영상 생성 실패로 영상 전송 통신 취소." << std::endl;
 		setIsDBThreadRunningFalse();
 		return false;
 	}
@@ -63,12 +63,12 @@ bool DBThread::sendDataToDB() {
 	bool success = sendVideoToBackend(videoData);
 
 	if (success) {
-		std::cout << "백엔드 영상 저장 성공, 로컬 폴더 삭제 : " << folderPath << std::endl;
+		//std::cout << "백엔드 영상 저장 성공, 로컬 폴더 삭제 : " << folderPath << std::endl;
 		deleteFolderSafe(folderPath);
 		setIsDBThreadRunningFalse();
 		return true;
 	} else {
-		std::cerr << "백엔드 전송 실패, 로컬 폴더 삭제 : " << folderPath << std::endl;
+		//std::cerr << "백엔드 전송 실패, 로컬 폴더 삭제 : " << folderPath << std::endl;
 		deleteFolderSafe(folderPath);
 		setIsDBThreadRunningFalse();
 		return false;

--- a/src/DBThreadMonitoring.cpp
+++ b/src/DBThreadMonitoring.cpp
@@ -7,7 +7,7 @@ std::string DBThreadMonitoring::generateThreadKey(const std::string& deviceUid, 
 }
 
 DBThreadMonitoring::DBThreadMonitoring() {
-    startDBMonitoring();
+    //startDBMonitoring();
 }
 
 DBThreadMonitoring::~DBThreadMonitoring() {
@@ -19,9 +19,14 @@ DBThreadMonitoring::~DBThreadMonitoring() {
 }
 
 void DBThreadMonitoring::startDBMonitoring() {
-    monitoringThread = std::thread([this] {
-        processThreadQueue();
-    });
+    try {
+        monitoringThread = std::thread([this] {
+            processThreadQueue();
+            });
+    }
+    catch (const std::exception& e) {
+        std::cout << "Error during starting thread: " << e.what() << std::endl;
+    }
 }
 
 void DBThreadMonitoring::processThreadQueue() {
@@ -42,7 +47,7 @@ void DBThreadMonitoring::processThreadQueue() {
                     ptr->sendDataToDB();
                 }
                 catch (const std::exception& e) {
-                    std::cerr << "DBThread 예외: " << e.what() << std::endl;
+                    std::cerr << "DBThread exception: " << e.what() << std::endl;
                 }
                 removeActiveThread(generateThreadKey(ptr->getDeviceUid(), ptr->getFolderPath()));
                 }).detach();
@@ -59,10 +64,10 @@ void DBThreadMonitoring::addDBThread(std::shared_ptr<DBThread> thread) {
         activeThreadKeys.insert(threadKey);
         threadQueue.push(thread);
         condition.notify_one();
-        std::cout << "DBThread 추가됨, 큐 크기: " << threadQueue.size() << std::endl;
+        std::cout << "DBThread added, queue size: " << threadQueue.size() << std::endl;
     }
     else {
-        std::cout << "이미 실행 중인 스레드입니다 : " << threadKey << std::endl;
+        std::cout << "thread is already started : " << threadKey << std::endl;
     }
 }
 

--- a/src/EyeClosureQueueManagement.cpp
+++ b/src/EyeClosureQueueManagement.cpp
@@ -28,35 +28,27 @@ void EyeClosureQueueManagement::saveEyeClosureStatus(bool eyeClosed) {
 }
 
 bool EyeClosureQueueManagement::detectSleepiness() {
-	// 덱의 데이터가 CONSECUTIVE_FRAMES_FOR_SLEEPINESS보다 적으면 졸음이 아님
 	if (eyeClosureDeque.size() < CONSECUTIVE_FRAMES_FOR_SLEEPINESS) {
-		std::cout << "Deque size (" << eyeClosureDeque.size()
-							<< ") is less than required consecutive frames (" << CONSECUTIVE_FRAMES_FOR_SLEEPINESS
-							<< ") for sleepiness detection." << std::endl;
 		return false;
 	}
 
-	// 가장 최근 프레임부터 역순으로 연속된 눈 감음 검사
-	int consecutiveClosedCount = 0;
+	int consecutiveClosedFrames = 0;
+	int maxConsecutiveClosedFrames = 0;
 
-	// 덱을 반복하면서 연속된 눈 감음 상태 검사
-	for (int i = eyeClosureDeque.size() - 1; i >= 0; i--) {
-		if (eyeClosureDeque[i]) {
-			consecutiveClosedCount++;
-
-			// 연속된 눈 감음 프레임이 기준치에 도달하면 졸음으로 판단
-			if (consecutiveClosedCount >= CONSECUTIVE_FRAMES_FOR_SLEEPINESS) {
-				std::cout << "Detected sleepiness: " << consecutiveClosedCount
-									<< " consecutive closed-eye frames." << std::endl;
-				return true;
-			}
-		} else {
-			// 눈 감음이 연속되지 않으면 카운트 리셋
-			consecutiveClosedCount = 0;
+	// deque의 뒤에서부터 앞으로 순회하면서 현재 연속된 감김 프레임 수를 계산
+	for (auto it = eyeClosureDeque.rbegin(); it != eyeClosureDeque.rend(); ++it) {
+		if (*it) {	// 눈이 감긴 상태
+			consecutiveClosedFrames++;
+			maxConsecutiveClosedFrames = std::max(maxConsecutiveClosedFrames, consecutiveClosedFrames);
+		}
+		else {	// 눈이 열린 상태
+			break;	// 연속성이 깨졌으므로 중단
 		}
 	}
 
-	std::cout << "No sleepiness detected. Maximum consecutive closed-eye frames: "
-						<< consecutiveClosedCount << std::endl;
-	return false;
+	std::cout << "Current consecutive closed frames from end: " << consecutiveClosedFrames
+		<< std::endl;
+
+	// 현재 시점에서 연속으로 감긴 프레임이 임계값 이상인지 확인
+	return consecutiveClosedFrames >= CONSECUTIVE_FRAMES_FOR_SLEEPINESS;
 }

--- a/src/FirmwareManager.cpp
+++ b/src/FirmwareManager.cpp
@@ -436,14 +436,16 @@ bool FirmwareManager::requestDiagnosis() {
 	}
 	else {
 		previousSleepy = false;
-
-		// 스택에 저장된 졸음 근거 영상 폴더를 전부 DB 전송 스레드에 추가
-		while (!sleepImgPathStack.empty()) {
+		if (!sleepImgPathStack.empty()) {
 			std::string sleepDir = utils->saveDirectory + sleepImgPathStack.top();
 			sleepImgPathStack.pop();
-
 			auto dbThread = std::make_shared<DBThread>(deviceUID, sleepDir, threadMonitor.get());
 			threadMonitor->addDBThread(dbThread);
+		}
+
+		// 스택에 저장된 필요 없는 졸음 근거 영상 경로 제거
+		while (!sleepImgPathStack.empty()) {
+			sleepImgPathStack.pop();
 		}
 		threadMonitor->setIsDBThreadRunning(true);
 		diagnosticCycle++;

--- a/src/FirmwareManager.cpp
+++ b/src/FirmwareManager.cpp
@@ -14,6 +14,13 @@
 
 // NumPy 배열 초기화를 위한 헬퍼 함수
 bool FirmwareManager::initializePythonAndNumpy() {
+
+	wchar_t* pythonHome = Py_DecodeLocale("C:/Users/twin4/AppData/Local/Programs/Python/Python313", nullptr);
+	Py_SetPythonHome(pythonHome);
+
+	wchar_t* programName = Py_DecodeLocale("C:/Users/twin4/AppData/Local/Programs/Python/Python313/python.exe", nullptr);
+	Py_SetProgramName(programName);
+
 	Py_Initialize();
 	if (!Py_IsInitialized()) {
 		std::cerr << "Failed to initialize Python interpreter" << std::endl;
@@ -24,7 +31,8 @@ bool FirmwareManager::initializePythonAndNumpy() {
 	import_array1(false);
 
 	PyRun_SimpleString(
-			"import sys; sys.path.append('.'); sys.path.append('..'); sys.path.append('../python')");
+			"import sys; sys.path.append('C:/github/NoSleepDrive/embedded/python');  sys.path.append('C:/Users/twin4/AppData/Local/Programs/Python/Python313/Lib/site-packages');");
+
 
 	return true;
 }

--- a/src/SleepinessDetector.cpp
+++ b/src/SleepinessDetector.cpp
@@ -74,11 +74,15 @@ void SleepinessDetector::sendDriverFrame(const cv::Mat& frame) {
 	std::string url = serverIP + "/api/save/frame";
 
 	// API 요청
-	cpr::Response r = cpr::Post(cpr::Url{url}, cpr::Header{{"Content-Type", "application/json"}},
-															cpr::Body{jsonData.dump()});
+	std::thread([](std::string url, std::string data) {
+		cpr::Post(cpr::Url{ url },
+		cpr::Header{ {"Content-Type", "application/json"} },
+		cpr::Body{ data });
+		}, url, jsonData.dump()).detach();
+
 
 	// 응답 처리
-	if (r.status_code == 200) {
+	/*if (r.status_code == 200) {
 		try {
 			nlohmann::json response = nlohmann::json::parse(r.text);
 
@@ -107,7 +111,7 @@ void SleepinessDetector::sendDriverFrame(const cv::Mat& frame) {
 		} catch (const std::exception& e) {
 			std::cerr << "오류 응답 파싱 실패: " << e.what() << std::endl;
 		}
-	}
+	}*/
 }
 
 bool SleepinessDetector::requestAIDetection(const std::string& uid,

--- a/src/SleepinessDetector.cpp
+++ b/src/SleepinessDetector.cpp
@@ -146,19 +146,19 @@ bool SleepinessDetector::requestAIDetection(const std::string& uid,
 			bool isDrowsy = jsonResp["isDrowsinessDrive"];
 			std::string detectionTime = jsonResp["detectionTime"];
 
-			std::cout << "AI 진단 성공 - 졸음 운전 여부: " << (isDrowsy ? "예" : "아니오")
-								<< ", 감지 시각: " << detectionTime << std::endl;
+			//std::cout << "AI 진단 성공 - 졸음 운전 여부: " << (isDrowsy ? "예" : "아니오")
+			//					<< ", 감지 시각: " << detectionTime << std::endl;
 
 			return isDrowsy;
 		} else {
 			const auto& err = jsonResp["error"];
-			std::cerr << "AI 서버 오류 - 코드: " << err["code"] << ", 메시지: " << err["message"]
-								<< ", 메서드: " << err["method"] << ", 상세: " << err["detail_message"]
-								<< std::endl;
+			//std::cerr << "AI 서버 오류 - 코드: " << err["code"] << ", 메시지: " << err["message"]
+			//					<< ", 메서드: " << err["method"] << ", 상세: " << err["detail_message"]
+			//					<< std::endl;
 			return false;
 		}
 	} catch (const std::exception& e) {
-		std::cerr << "JSON 파싱 오류: " << e.what() << std::endl;
+		//std::cerr << "JSON 파싱 오류: " << e.what() << std::endl;
 		return false;
 	}
 }

--- a/src/SleepinessDetector.cpp
+++ b/src/SleepinessDetector.cpp
@@ -80,42 +80,9 @@ void SleepinessDetector::sendDriverFrame(const cv::Mat& frame) {
 		cpr::Body{ data });
 		}, url, jsonData.dump()).detach();
 
-
-	// 응답 처리
-	/*if (r.status_code == 200) {
-		try {
-			nlohmann::json response = nlohmann::json::parse(r.text);
-
-			if (response.contains("success") && response["success"] == true) {
-				std::cout << "프레임 #" << (frameIndex - 1) << " 전송 성공" << std::endl;
-			} else {
-				std::cerr << "프레임 전송 실패 - 응답: " << r.text << std::endl;
-			}
-		} catch (const std::exception& e) {
-			std::cerr << "응답 파싱 오류: " << e.what() << std::endl;
-		}
-	} else {
-		std::cerr << "프레임 전송 실패 - 상태 코드: " << r.status_code << std::endl;
-
-		try {
-			nlohmann::json response = nlohmann::json::parse(r.text);
-
-			if (response.contains("success") && response["success"] == false &&
-					response.contains("error")) {
-				auto& error = response["error"];
-				std::cerr << "오류 코드: " << error["code"] << std::endl;
-				std::cerr << "오류 메시지: " << error["message"] << std::endl;
-				std::cerr << "오류 메서드: " << error["method"] << std::endl;
-				std::cerr << "상세 메시지: " << error["detail_message"] << std::endl;
-			}
-		} catch (const std::exception& e) {
-			std::cerr << "오류 응답 파싱 실패: " << e.what() << std::endl;
-		}
-	}*/
 }
 
-bool SleepinessDetector::requestAIDetection(const std::string& uid,
-																						const std::string& requestTime) {
+bool SleepinessDetector::requestAIDetection(const std::string& uid, const std::string& requestTime) {
 	std::cout << "AI Server 진단 요청하는 파이 UID : " << uid << " 및 요청 시각 : " << requestTime
 						<< std::endl;
 
@@ -135,7 +102,10 @@ bool SleepinessDetector::requestAIDetection(const std::string& uid,
 
 	std::string url = serverIP + "/diagnosis/drowiness?deviceUid=" + encodedUid;
 
-	cpr::Response r = cpr::Get(cpr::Url{url});
+	cpr::Response r = cpr::Get(
+		cpr::Url{url},
+		cpr::Timeout{ 3000 }
+	);
 
 	if (r.status_code != 200) {
 		std::cerr << "서버 응답 실패 - 상태 코드: " << r.status_code << "\n본문: " << r.text

--- a/src/SleepinessDetector.cpp
+++ b/src/SleepinessDetector.cpp
@@ -71,7 +71,7 @@ void SleepinessDetector::sendDriverFrame(const cv::Mat& frame) {
 			{"deviceUid", deviceUidEnv}, {"frameIdx", frameIndex++}, {"driverFrame", base64Image}};
 
 	// 요청 URL 생성
-	std::string url = serverIP + "/api/save/frame";
+	std::string url = serverIP + "/save/frame";
 
 	// API 요청
 	std::thread([](std::string url, std::string data) {

--- a/src/Speaker.cpp
+++ b/src/Speaker.cpp
@@ -1,94 +1,105 @@
 #include "../include/Speaker.h"
 
-#include <cstdlib>
 #include <filesystem>
 #include <iostream>
 #include <string>
+#include <cstdlib>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <mmsystem.h>
+#pragma comment(lib, "Winmm.lib")
+#endif
 
 Speaker::Speaker(const std::string& soundFilePath, int vol)
-		: Device(), alertSoundFilePath(soundFilePath), volume(vol) {}
+    : Device(), alertSoundFilePath(soundFilePath), volume(vol) {}
 
 Speaker::~Speaker() {}
 
 void Speaker::initialize() {
-	// VLC 플레이어 설치 확인
-	int result = system("which cvlc > /dev/null 2>&1");
+#ifdef _WIN32
+    if (!std::filesystem::exists(alertSoundFilePath)) {
+        std::cerr << "Warning: Sound file not found: " << alertSoundFilePath << std::endl;
+        setConnectionStatus(false);
+        updateDeviceStatus(2, false);
+    }
+    else {
+        setConnectionStatus(true);
+        updateDeviceStatus(2, true);
+        std::cout << "Speaker initialized successfully (Windows)" << std::endl;
+    }
+#else
+    int result = system("which cvlc > /dev/null 2>&1");
 
-	if (result != 0) {
-		std::cerr << "Error: VLC player not found. Please install it using: sudo apt-get install vlc"
-							<< std::endl;
-		setConnectionStatus(false);
-		updateDeviceStatus(2, false);	 // 스피커는 인덱스 2
-	} else {
-		// 사운드 파일이 존재하는지 확인
-		if (!std::filesystem::exists(alertSoundFilePath)) {
-			std::cerr << "Warning: Alert sound file not found at: " << alertSoundFilePath << std::endl;
-			std::cerr << "Speaker will be marked as connected, but alert may not work" << std::endl;
-		}
+    if (result != 0) {
+        std::cerr << "Error: VLC player not found. Install with: sudo apt install vlc" << std::endl;
+        setConnectionStatus(false);
+        updateDeviceStatus(2, false);
+    }
+    else {
+        if (!std::filesystem::exists(alertSoundFilePath)) {
+            std::cerr << "Warning: Sound file not found: " << alertSoundFilePath << std::endl;
+        }
 
-		setConnectionStatus(true);
-		updateDeviceStatus(2, true);	// 스피커는 인덱스 2
-		std::cout << "Speaker initialized successfully with VLC player" << std::endl;
-	}
+        setConnectionStatus(true);
+        updateDeviceStatus(2, true);
+        std::cout << "Speaker initialized successfully with VLC (Linux)" << std::endl;
+    }
+#endif
 
-	sendDeviceStatus();
+    sendDeviceStatus();
 }
 
 void Speaker::setAlert(const std::string& soundFile, int vol) {
-	alertSoundFilePath = soundFile;
-	volume = vol;
+    alertSoundFilePath = soundFile;
+    volume = vol;
 }
 
 void Speaker::triggerAlert() {
-	if (!getConnectionStatus()) {
-		std::cerr << "Cannot trigger alert: Speaker not connected" << std::endl;
-		return;
-	}
+    if (!getConnectionStatus()) {
+        std::cerr << "Speaker not connected" << std::endl;
+        return;
+    }
 
-	// 파일이 존재하는지 확인
-	if (!std::filesystem::exists(alertSoundFilePath)) {
-		std::cerr << "Error: Alert sound file not found at: " << alertSoundFilePath << std::endl;
-		return;
-	}
+    if (!std::filesystem::exists(alertSoundFilePath)) {
+        std::cerr << "Sound file not found: " << alertSoundFilePath << std::endl;
+        return;
+    }
 
-	std::cout << "Playing alert sound: " << alertSoundFilePath << " at volume " << volume << "%"
-						<< std::endl;
+#ifdef _WIN32
+    std::cout << "Playing alert (Windows): " << alertSoundFilePath << std::endl;
+    PlaySound(alertSoundFilePath.c_str(), NULL, SND_FILENAME | SND_ASYNC);
+#else
+    int vlcVolume = volume * 256 / 100;
+    std::string command =
+        "cvlc --play-and-exit --no-loop --gain=" + std::to_string(vlcVolume / 256.0) +
+        " --no-video \"" + alertSoundFilePath + "\" >/dev/null 2>&1 &";
+    int result = system(command.c_str());
 
-	// VLC 명령어 구성
-	// cvlc: 콘솔 모드 VLC (GUI 없음)
-	// --play-and-exit: 재생 후 자동 종료
-	// --no-loop: 반복 재생 없음
-	// --volume=NNN: 볼륨 설정 (0-512, 100%는 256)
-	// --no-video: 비디오 출력 없음
-	// >/dev/null 2>&1 &: 출력 무시하고 백그라운드로 실행
-
-	int vlcVolume = volume * 256 / 100;	 // VLC 볼륨은 0-512 범위 (100%는 256)
-	std::string command =
-			"cvlc --play-and-exit --no-loop --gain=" + std::to_string(vlcVolume / 256.0) +
-			" --no-video \"" + alertSoundFilePath + "\" >/dev/null 2>&1 &";
-
-	int result = system(command.c_str());
-
-	if (result != 0) {
-		std::cerr << "Failed to play alert sound. Error code: " << result << std::endl;
-	} else {
-		std::cout << "Alert triggered successfully" << std::endl;
-	}
+    if (result != 0) {
+        std::cerr << "Failed to play alert. Error code: " << result << std::endl;
+    }
+    else {
+        std::cout << "Alert triggered (Linux)" << std::endl;
+    }
+#endif
 }
 
 void Speaker::setVolume(int vol) {
-	if (vol < 0) vol = 0;
-	if (vol > 100) vol = 100;
+    if (vol < 0) vol = 0;
+    if (vol > 100) vol = 100;
 
-	volume = vol;
+    volume = vol;
 
-	// 라즈베리파이 시스템 볼륨 설정
-	std::string command = "amixer set Master " + std::to_string(volume) + "% -q";
-	system(command.c_str());
-
-	std::cout << "System volume set to " << volume << "%" << std::endl;
+#ifdef _WIN32
+    std::cout << "Volume updated (Windows): " << volume << "%" << std::endl;
+#else
+    std::string command = "amixer set Master " + std::to_string(volume) + "% -q";
+    system(command.c_str());
+    std::cout << "System volume set to " << volume << "%" << std::endl;
+#endif
 }
 
 int Speaker::getVolume() const {
-	return volume;
+    return volume;
 }

--- a/src/VideoEncoder.cpp
+++ b/src/VideoEncoder.cpp
@@ -10,7 +10,7 @@
 
 std::vector<uchar> VideoEncoder::convertFramesToMP4(const std::string& path) {
     // example path(folderPath): ./frames/20250519_023859
-    std::cout << "파일 경로 " << path << " 생성 시간 기준 전후 각각 2.5초 이미지 프레임들을 영상으로 변환" << std::endl;
+    //std::cout << "파일 경로 " << path << " 생성 시간 기준 전후 각각 2.5초 이미지 프레임들을 영상으로 변환" << std::endl;
     std::vector<cv::String> framePaths;
     std::vector<uchar> videoBuffer;
 
@@ -20,7 +20,7 @@ std::vector<uchar> VideoEncoder::convertFramesToMP4(const std::string& path) {
     ss >> std::get_time(&folderTime, "%Y%m%d_%H%M%S");
 
     if (ss.fail()) {
-        std::cerr << "폴더 이름에서 타임스탬프를 파싱할 수 없음: " << folderName << std::endl;
+        //std::cerr << "폴더 이름에서 타임스탬프를 파싱할 수 없음: " << folderName << std::endl;
         return videoBuffer;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,7 @@ int main(int argc, char* argv[]) {
 	std::signal(SIGINT, signalHandler);
 	std::signal(SIGTERM, signalHandler);
 
-	std::cout << "NoSleep Drive 서비스 시작 중..." << std::endl;
+	std::cout << "NoSleep Drive service starting..." << std::endl;
 
 	// 환경 변수 설정 로드
 	Utils envLoader;
@@ -43,8 +43,8 @@ int main(int argc, char* argv[]) {
 	try {
 		// 시스템 시작
 		manager->start();
-		std::cout << "NoSleep Drive 시스템이 성공적으로 시작되었습니다." << std::endl;
-		std::cout << "장치 ID: " << deviceUID << std::endl;
+		std::cout << "NoSleep Drive system Started Successfully" << std::endl;
+		std::cout << "device ID: " << deviceUID << std::endl;
 
 		// 메인 루프
 		while (running) {
@@ -54,13 +54,13 @@ int main(int argc, char* argv[]) {
 		}
 
 		// 정상 종료 처리
-		std::cout << "시스템 종료 중..." << std::endl;
+		std::cout << "system terminating..." << std::endl;
 		manager->stop();
 	} catch (const std::exception& e) {
-		std::cerr << "오류 발생: " << e.what() << std::endl;
+		std::cerr << "error occured: " << e.what() << std::endl;
 		return 1;
 	}
 
-	std::cout << "NoSleep Drive 서비스가 정상적으로 종료되었습니다." << std::endl;
+	std::cout << "NoSleep Drive Service terminated Successfully." << std::endl;
 	return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@ std::atomic<bool> running(true);
 
 // SIGINT(Ctrl+C) 및 SIGTERM 핸들러
 void signalHandler(int signum) {
-	std::cout << "인터럽트 시그널 (" << signum << ") 수신. 종료 중..." << std::endl;
+	std::cout << "interrupt signal (" << signum << ") received. terminating..." << std::endl;
 	running = false;
 }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closed #28 

## 📝 작업 내용

윈도우 환경에서 임베디드 코드를 직접 실행해보고 로직 오류와 혹시나 모를 임베디드 장치 고장을 대비합니다.
- [x] 윈도우 환경 빌드 확인
- [x] 빌드까지의 과정 문서 정리
- [x] 카메라 및 스피커 등 window 환경에 맞게 코드 분기 처리
- [x] 기능 확인
  - [x] 이미지 저장
  - [x] thread 동작
  - [x] 가속도 센서 mocking 체크


### 25.06.25 변경 사항 추가
- [x] 졸음 영상 생성 방식을 openCV에서 ffmpeg 처리를 추가하여 스트리밍이 안되는 버그 수정
- [x] 졸음 영상 프레임 오류 수정

졸음 영상 프레임을 recent에서 가져올 때, 기존엔 stoll로 변환하여 ±2500를 통해 좌우를 비교하여 가져오는데 `%Y%m%d_%H%M%S`의 형식으로 가져오면 알맞게 비교할 수 없었습니다.
때문에 졸음 진단 시 영상의 중단부 부분이 빠지는 오류가 발생한 것으로 보입니다.

파일 명을 따로 파싱하여 비교하는 방식으로 해결했습니다.


### 📸 스크린샷 (선택)


## 💬 리뷰 요청사항 (선택)

아래 두 문서로 나누어 문서화를 진행했습니다. 

https://www.notion.so/embedded-window-200cd825ecaf802ba2f9ee6b7d297082
https://www.notion.so/embedded-window-200cd825ecaf80c1a834fc5b7cea8ebc

---
### 회의에서 추가로 이야기 나눌 부분

- env 파일 확인하면서 든 의문입니다.
  - ai 서버 배포는 포트 8080이고 뒤에 /api가 붙는 형식인가요?
  - api를 붙이게 되면 443으로 들어오는 url이 BE와 구별을 못하게 되어서, 혹시 괜찮다면 prefix 값을 /ai 같은 형식으로 할 수 있을지 궁금합니다.
  
- 라즈베리 파이에서도 이미지 ai서버로 전송하는 거 기다리나요?
```C++
void SleepinessDetector::sendDriverFrame(const cv::Mat& frame) {
	static int frameIndex = 0;

	// 이미지 데이터 인코딩
	std::vector<uchar> buffer;
	cv::imencode(".jpg", frame, buffer);

	std::string base64Image = base64_encode(std::string(buffer.begin(), buffer.end()));

	const char* uidC = std::getenv("DEVICE_UID");
	const char* ipC = std::getenv("AI_SERVER_IP");

	if (!uidC || !ipC) {
		std::cerr << "환경 변수 설정 오류: 통신에 필요한 정보 누락" << std::endl;
		return;
	}

	std::string deviceUidEnv(uidC);
	std::string serverIP(ipC);

	// 요청 데이터 생성
	nlohmann::json jsonData = {
			{"deviceUid", deviceUidEnv}, {"frameIdx", frameIndex++}, {"driverFrame", base64Image}};

	// 요청 URL 생성
	std::string url = serverIP + "/api/save/frame";

	// API 요청
	cpr::Response r = cpr::Post(cpr::Url{url}, cpr::Header{{"Content-Type", "application/json"}},
															cpr::Body{jsonData.dump()});

	// 응답 처리
	if (r.status_code == 200) {
		try {
			nlohmann::json response = nlohmann::json::parse(r.text);

			if (response.contains("success") && response["success"] == true) {
				std::cout << "프레임 #" << (frameIndex - 1) << " 전송 성공" << std::endl;
			} else {
				std::cerr << "프레임 전송 실패 - 응답: " << r.text << std::endl;
			}
		} catch (const std::exception& e) {
			std::cerr << "응답 파싱 오류: " << e.what() << std::endl;
		}
	} else {
		std::cerr << "프레임 전송 실패 - 상태 코드: " << r.status_code << std::endl;

		try {
			nlohmann::json response = nlohmann::json::parse(r.text);

			if (response.contains("success") && response["success"] == false &&
					response.contains("error")) {
				auto& error = response["error"];
				std::cerr << "오류 코드: " << error["code"] << std::endl;
				std::cerr << "오류 메시지: " << error["message"] << std::endl;
				std::cerr << "오류 메서드: " << error["method"] << std::endl;
				std::cerr << "상세 메시지: " << error["detail_message"] << std::endl;
			}
		} catch (const std::exception& e) {
			std::cerr << "오류 응답 파싱 실패: " << e.what() << std::endl;
		}
	}
}
```

  -> 위 코드 내 요청이 동기로 처리되는 것을 확인했습니다. 설계 상에선, ai 서버가 이미지 프레임을 누락하여 받더라도 ai 서버가 내부적으로 처리하지 임베디드 쪽에서 처리할 일이 없습니다.

  -> 이렇게 동기로 처리될 경우, frame 전송 요청 응답을 기다리느라 이미지 처리에 지연이 생기는 것으로 보입니다.
  -> window는 ai 서버 연결이 안 될 시 지연이 생기는 점을 확인했습니다만, 리눅스 환경을 가진 라즈베리파이는 지연이 안 생기나요? 윈도우 테스트 브랜치를 따로 관리할 예정이라 수정은 진행이 되었지만 main에는 반영이 되지 않습니다. 
  -> 만약 리눅스에서도 지연이 생기는 방식이라면 수정이 필요할 것 같습니다!
