### PR TITLE
[Fix] 리눅스 컴파일 완료 및 통신 로직 개선 (#33)

### DIFF
--- a/include/Device.h
+++ b/include/Device.h
@@ -6,22 +6,43 @@
 #include <string>
 #include <vector>
 
+// 전역 장치 상태 관리를 위한 싱글톤 클래스
+class DeviceStatusManager {
+public:
+	static DeviceStatusManager& getInstance();
+
+	// 장치 상태 업데이트
+	void updateDeviceStatus(int deviceIndex, bool status);
+
+	// 전체 장치 상태 조회
+	std::vector<bool> getAllDeviceStatus() const;
+
+	// 특정 장치 상태 조회
+	bool getDeviceStatus(int deviceIndex) const;
+
+	// 백엔드로 장치 상태 전송
+	void sendDeviceStatusToBackend();
+
+private:
+	DeviceStatusManager();
+	std::vector<bool> deviceStatus;	 // [0] = 카메라, [1] = 가속도 센서, [2] = 스피커
+};
+
 class Device {
 protected:
 	bool isConnected;
 	bool isDeviceChanged;
-	std::vector<bool> deviceStatus;
 
 public:
 	Device();
 	virtual ~Device();
 
 	virtual void initialize() = 0;
-	void sendDeviceStatus();
 
 	bool getConnectionStatus() const;
 	void setConnectionStatus(bool status);
-	std::vector<bool> getDeviceStatus() const;
+
+	// 장치 상태 업데이트 (전역 상태 매니저 사용)
 	void updateDeviceStatus(int deviceIndex, bool status);
 };
 

--- a/include/Device.h
+++ b/include/Device.h
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
 

--- a/include/FirmwareManager.h
+++ b/include/FirmwareManager.h
@@ -46,11 +46,12 @@ private:
 
 	// 스레드
 	std::thread mainThread;
+	std::mutex detectionMutex;
 
 	// 내부 메서드
 	void mainLoop();
 	bool processSingleFrame();
-	bool requestDiagnosis();
+	void requestDiagnosis();
 	void initializeDevices();
 	void handleVehicleStopped();
 	void handleSleepinessDetected(const std::string& timestamp);

--- a/include/FirmwareManager.h
+++ b/include/FirmwareManager.h
@@ -55,6 +55,9 @@ private:
 	void handleVehicleStopped();
 	void handleSleepinessDetected(const std::string& timestamp);
 
+	// 장치 상태 백엔드 전송
+	void sendDeviceStatusToBackend();
+
 	// NumPy 초기화 메서드
 	bool initializePythonAndNumpy();
 

--- a/include/SleepinessDetector.h
+++ b/include/SleepinessDetector.h
@@ -1,25 +1,28 @@
 #ifndef SLEEPINESS_DETECTOR_H
 #define SLEEPINESS_DETECTOR_H
 
-#include <string>
-#include <stack>
-#include <queue>
 #include <opencv2/opencv.hpp>
+#include <queue>
+#include <stack>
+#include <string>
+
 #include "EyeClosureQueueManagement.h"
 
 class SleepinessDetector {
 private:
-    static const int closureCountForSleepiness = 48;
-    std::string sleepImgPath;
-    std::stack<std::string> sleepImgPathStack;
+	static const int closureCountForSleepiness = 48;
+	std::string sleepImgPath;
+	std::stack<std::string> sleepImgPathStack;
 
 public:
-    SleepinessDetector();
+	SleepinessDetector();
 
-    void sendDriverFrame(const cv::Mat& frame);
-    bool requestAIDetection(const std::string& uid, const std::string& requestTime);
-    bool getLocalDetection(EyeClosureQueueManagement& eyeManager);
-    void updateBaseSleepImgPath(const std::string& path);
+	void sendDriverFrame(const cv::Mat& frame);
+	void requestAIDetection(
+			const std::string& uid, const std::string& requestTime,
+			std::function<void(bool success, bool isDrowsy, const std::string& message)> callback);
+	bool getLocalDetection(EyeClosureQueueManagement& eyeManager);
+	void updateBaseSleepImgPath(const std::string& path);
 };
 
 #endif

--- a/python/eye_detection_lib.py
+++ b/python/eye_detection_lib.py
@@ -27,7 +27,7 @@ def initialize():
     global predictor
     try:
         # Load face landmark model
-        predictor = dlib.shape_predictor("shape_predictor_68_face_landmarks.dat")
+        predictor = dlib.shape_predictor("../shape_predictor_68_face_landmarks.dat")
         return True
     except Exception as e:
         print(f"[ERROR] Error during initialization: {e}")

--- a/src/AccelerationSensor.cpp
+++ b/src/AccelerationSensor.cpp
@@ -147,7 +147,7 @@ MockAccelerationSensor::MockAccelerationSensor()
 		: xAcceleration(0.0f),
 			yAcceleration(0.0f),
 			zAcceleration(9.8f),
-			moving(false),
+			moving(true),
 			rng(std::chrono::system_clock::now().time_since_epoch().count()),
 			dist(-0.2f, 0.2f) {}
 
@@ -193,6 +193,8 @@ AccelerationSensor::AccelerationSensor(bool useMock) : Device(), useMock(useMock
 AccelerationSensor::~AccelerationSensor() {}
 
 void AccelerationSensor::initialize() {
+	std::cout << "가속도 센서 초기화 중..." << std::endl;
+
 	// Try to get acceleration data to check if sensor is working
 	std::vector<float> accel = sensor->getAcceleration();
 
@@ -202,8 +204,7 @@ void AccelerationSensor::initialize() {
 	setConnectionStatus(sensorWorking);
 	updateDeviceStatus(1, sensorWorking);	 // Accelerometer is index 1
 
-	// Send updated status to backend
-	sendDeviceStatus();
+	std::cout << "가속도 센서 초기화 " << (sensorWorking ? "성공" : "실패") << std::endl;
 }
 
 bool AccelerationSensor::isMoving() {

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -15,6 +15,8 @@ Camera::~Camera() {
 }
 
 void Camera::initialize() {
+	std::cout << "카메라 초기화 중..." << std::endl;
+
 	// GStreamer 파이프라인 구성
 	gstreamerPipeline = "libcamerasrc camera-name=" + cameraName +
 											" ! video/x-raw,width=" + std::to_string(resolution[0]) +
@@ -78,7 +80,8 @@ void Camera::setCameraStatus(bool status) {
 }
 
 bool Camera::getCameraStatus() const {
-	return deviceStatus[0];
+	// 전역 상태 매니저에서 카메라 상태 조회
+	return DeviceStatusManager::getInstance().getDeviceStatus(0);
 }
 
 void Camera::setResolution(int width, int height) {

--- a/src/Device.cpp
+++ b/src/Device.cpp
@@ -76,10 +76,13 @@ void DeviceStatusManager::sendDeviceStatusToBackend() {
 						<< std::endl;
 
 	try {
-		cpr::Response r =
-				cpr::Patch(cpr::Url{serverIP + "/vehicles/status"}, headers, cpr::Body{jsonBody});
+		cpr::Response r = cpr::Patch(cpr::Url{serverIP + "/vehicles/status"}, headers,
+																 cpr::Body{jsonBody}, cpr::Timeout{5000}	// 5초 타임아웃
+		);
 
-		if (r.status_code == 200) {
+		if (r.error) {
+			std::cerr << "장치 상태 전송 오류: " << r.error.message << std::endl;
+		} else if (r.status_code == 200) {
 			std::cout << "장치 상태 전송 성공" << std::endl;
 		} else {
 			std::cerr << "장치 상태 전송 실패 - 상태 코드: " << r.status_code << ", 응답: " << r.text

--- a/src/Device.cpp
+++ b/src/Device.cpp
@@ -1,11 +1,97 @@
 #include "../include/Device.h"
+
 #include <cpr/cpr.h>
+
+#include <iostream>
+
 #include "../include/Utils.h"
 
-Device::Device() : isConnected(false), isDeviceChanged(false) {
+// DeviceStatusManager 구현
+DeviceStatusManager& DeviceStatusManager::getInstance() {
+	static DeviceStatusManager instance;
+	return instance;
+}
+
+DeviceStatusManager::DeviceStatusManager() {
 	// 장치 상태 벡터: [0] = 카메라, [1] = 가속도 센서, [2] = 스피커
 	deviceStatus = {false, false, false};
 }
+
+void DeviceStatusManager::updateDeviceStatus(int deviceIndex, bool status) {
+	if (deviceIndex >= 0 && deviceIndex < deviceStatus.size()) {
+		deviceStatus[deviceIndex] = status;
+		std::cout << "Device " << deviceIndex
+							<< " status updated to: " << (status ? "connected" : "disconnected") << std::endl;
+	}
+}
+
+std::vector<bool> DeviceStatusManager::getAllDeviceStatus() const {
+	return deviceStatus;
+}
+
+bool DeviceStatusManager::getDeviceStatus(int deviceIndex) const {
+	if (deviceIndex >= 0 && deviceIndex < deviceStatus.size()) {
+		return deviceStatus[deviceIndex];
+	}
+	return false;
+}
+
+void DeviceStatusManager::sendDeviceStatusToBackend() {
+	const char* hashC = std::getenv("EMBEDDED_HASH");
+	const char* uidC = std::getenv("DEVICE_UID");
+	const char* ipC = std::getenv("SERVER_IP");
+
+	if (!hashC || !uidC || !ipC) {
+		std::cerr << "환경 변수 설정 오류: 통신에 필요한 정보 누락" << std::endl;
+		return;
+	}
+
+	std::string hash(hashC);
+	std::string deviceUid(uidC);
+	std::string serverIP(ipC);
+
+	cpr::Header headers = {{"Content-Type", "application/json; charset=utf-8"},
+												 {"Authorization", "Bearer " + hash}};
+
+	std::string status_1 = deviceStatus[0] ? "true" : "false";
+	std::string status_2 = deviceStatus[1] ? "true" : "false";
+	std::string status_3 = deviceStatus[2] ? "true" : "false";
+
+	std::string jsonBody =
+			"{"
+			"\"deviceUid\": \"" +
+			deviceUid +
+			"\","
+			"\"cameraState\": " +
+			status_1 +
+			","
+			"\"accelerationSensorState\": " +
+			status_2 +
+			","
+			"\"speakerState\": " +
+			status_3 + "}";
+
+	std::cout << "백엔드로 장치 상태 전송 중..." << std::endl;
+	std::cout << "Camera: " << status_1 << ", AccelSensor: " << status_2 << ", Speaker: " << status_3
+						<< std::endl;
+
+	try {
+		cpr::Response r =
+				cpr::Patch(cpr::Url{serverIP + "/vehicles/status"}, headers, cpr::Body{jsonBody});
+
+		if (r.status_code == 200) {
+			std::cout << "장치 상태 전송 성공" << std::endl;
+		} else {
+			std::cerr << "장치 상태 전송 실패 - 상태 코드: " << r.status_code << ", 응답: " << r.text
+								<< std::endl;
+		}
+	} catch (const std::exception& e) {
+		std::cerr << "장치 상태 전송 중 예외 발생: " << e.what() << std::endl;
+	}
+}
+
+// Device 클래스 구현
+Device::Device() : isConnected(false), isDeviceChanged(false) {}
 
 Device::~Device() {}
 
@@ -18,41 +104,6 @@ void Device::setConnectionStatus(bool status) {
 	isDeviceChanged = true;
 }
 
-std::vector<bool> Device::getDeviceStatus() const {
-	return deviceStatus;
-}
-
 void Device::updateDeviceStatus(int deviceIndex, bool status) {
-	if (deviceIndex >= 0 && deviceIndex < deviceStatus.size()) {
-		deviceStatus[deviceIndex] = status;
-		isDeviceChanged = true;
-	}
-}
-
-void Device::sendDeviceStatus() {
-    std::string hash = getenv("EMBEDDED_HASH");
-    std::string deviceUid = getenv("DEVICE_UID");
-    std::string serverIP = getenv("SERVER_IP");
-
-    cpr::Header headers = {
-        {"Content-Type", "application/json; charset=utf-8"},
-        {"Authorization", "Bearer "+ hash}
-    };
-    std::string status_1 = deviceStatus[0] ? "true" : "false";
-    std::string status_2 = deviceStatus[1] ? "true" : "false";
-    std::string status_3 = deviceStatus[2] ? "true" : "false";
-
-
-    std::string jsonBody = "{"
-        "\"deviceUid\": \"" + deviceUid + "\","
-        "\"cameraState\": " + status_1 + ","
-        "\"accelerationSensorState\": " + status_2 + ","
-        "\"speakerState\": " + status_3+
-        "}";
-
-    cpr::Response r = cpr::Patch(
-        cpr::Url{ serverIP + "/vehicles/status" },
-        headers,
-        cpr::Body{ jsonBody }
-    );
+	DeviceStatusManager::getInstance().updateDeviceStatus(deviceIndex, status);
 }

--- a/src/Device.cpp
+++ b/src/Device.cpp
@@ -57,19 +57,11 @@ void DeviceStatusManager::sendDeviceStatusToBackend() {
 	std::string status_2 = deviceStatus[1] ? "true" : "false";
 	std::string status_3 = deviceStatus[2] ? "true" : "false";
 
-	std::string jsonBody =
-			"{"
-			"\"deviceUid\": \"" +
-			deviceUid +
-			"\","
-			"\"cameraState\": " +
-			status_1 +
-			","
-			"\"accelerationSensorState\": " +
-			status_2 +
-			","
-			"\"speakerState\": " +
-			status_3 + "}";
+	nlohmann::json jsonData = {{"deviceUid", deviceUid},
+														 {"cameraState", deviceStatus[0]},
+														 {"accelerationSensorState", deviceStatus[1]},
+														 {"speakerState", deviceStatus[2]}};
+	std::string jsonBody = jsonData.dump();
 
 	std::cout << "백엔드로 장치 상태 전송 중..." << std::endl;
 	std::cout << "Camera: " << status_1 << ", AccelSensor: " << status_2 << ", Speaker: " << status_3

--- a/src/FirmwareManager.cpp
+++ b/src/FirmwareManager.cpp
@@ -101,7 +101,7 @@ FirmwareManager::~FirmwareManager() {
 }
 
 void FirmwareManager::initializeDevices() {
-	std::cout << "Initializing devices..." << std::endl;
+	std::cout << "장치 초기화 시작..." << std::endl;
 
 	try {
 		// 장치 초기화
@@ -109,25 +109,30 @@ void FirmwareManager::initializeDevices() {
 		accelerationSensor->initialize();
 		speaker->initialize();
 
-		// 장치 상태 확인
-		if (!camera->getConnectionStatus()) {
-			std::cerr << "경고: 카메라가 제대로 초기화되지 않았습니다." << std::endl;
-		}
-
-		if (!accelerationSensor->getConnectionStatus()) {
-			std::cerr << "경고: 가속도 센서가 제대로 초기화되지 않았습니다." << std::endl;
-		}
-
-		if (!speaker->getConnectionStatus()) {
-			std::cerr << "경고: 스피커가 제대로 초기화되지 않았습니다." << std::endl;
-		}
+		// 모든 장치 초기화 완료 후 한 번에 백엔드로 상태 전송
+		sendDeviceStatusToBackend();
 
 	} catch (const std::exception& e) {
 		std::cerr << "장치 초기화 중 오류 발생: " << e.what() << std::endl;
+		sendDeviceStatusToBackend();
 		throw;
 	}
 
 	std::cout << "모든 장치 초기화 완료" << std::endl;
+}
+
+void FirmwareManager::sendDeviceStatusToBackend() {
+	std::cout << "=== 장치 상태 백엔드 전송 ===" << std::endl;
+
+	// 전역 장치 상태 매니저를 통해 백엔드로 상태 전송
+	DeviceStatusManager::getInstance().sendDeviceStatusToBackend();
+
+	// 장치 상태 로깅
+	auto deviceStatus = DeviceStatusManager::getInstance().getAllDeviceStatus();
+	std::cout << "현재 장치 상태:" << std::endl;
+	std::cout << "  - 카메라: " << (deviceStatus[0] ? "연결됨" : "연결 안됨") << std::endl;
+	std::cout << "  - 가속도 센서: " << (deviceStatus[1] ? "연결됨" : "연결 안됨") << std::endl;
+	std::cout << "  - 스피커: " << (deviceStatus[2] ? "연결됨" : "연결 안됨") << std::endl;
 }
 
 void FirmwareManager::start() {

--- a/src/SleepinessDetector.cpp
+++ b/src/SleepinessDetector.cpp
@@ -77,7 +77,7 @@ void SleepinessDetector::sendDriverFrame(const cv::Mat& frame) {
 	cpr::PostCallback(
 			[](cpr::Response r) {
 				if (r.error) {
-					std::cerr << "통신 오류: " << r.error.message << std::endl;
+					// std::cerr << "통신 오류: " << r.error.message << std::endl;
 				}
 			},
 			cpr::Url{url}, cpr::Header{{"Content-Type", "application/json"}}, cpr::Body{jsonData.dump()},
@@ -85,8 +85,9 @@ void SleepinessDetector::sendDriverFrame(const cv::Mat& frame) {
 	);
 }
 
-bool SleepinessDetector::requestAIDetection(const std::string& uid,
-																						const std::string& requestTime) {
+void SleepinessDetector::requestAIDetection(
+		const std::string& uid, const std::string& requestTime,
+		std::function<void(bool success, bool isDrowsy, const std::string& message)> callback) {
 	std::cout << "AI Server 진단 요청하는 파이 UID : " << uid << " 및 요청 시각 : " << requestTime
 						<< std::endl;
 
@@ -95,7 +96,8 @@ bool SleepinessDetector::requestAIDetection(const std::string& uid,
 
 	if (!uidC || !ipC) {
 		std::cerr << "환경 변수 설정 오류: 통신에 필요한 정보 누락" << std::endl;
-		return false;
+		callback(false, false, "환경 변수 설정 오류");
+		return;
 	}
 
 	std::string deviceUidEnv(uidC);
@@ -106,12 +108,20 @@ bool SleepinessDetector::requestAIDetection(const std::string& uid,
 
 	std::string url = serverIP + "/diagnosis/drowiness?deviceUid=" + encodedUid;
 
-	cpr::Response r = cpr::Get(cpr::Url{url});
+	// 동기 HTTP 요청 (2초 타임아웃)
+	cpr::Response r = cpr::Get(cpr::Url{url}, cpr::Timeout{2000});
+
+	if (r.error) {
+		std::cerr << "통신 오류: " << r.error.message << std::endl;
+		callback(false, false, "통신 오류: " + r.error.message);
+		return;
+	}
 
 	if (r.status_code != 200) {
 		std::cerr << "서버 응답 실패 - 상태 코드: " << r.status_code << "\n본문: " << r.text
 							<< std::endl;
-		return false;
+		callback(false, false, "HTTP 오류: " + std::to_string(r.status_code));
+		return;
 	}
 
 	try {
@@ -120,21 +130,16 @@ bool SleepinessDetector::requestAIDetection(const std::string& uid,
 		if (jsonResp.contains("success") && jsonResp["success"] == true) {
 			bool isDrowsy = jsonResp["isDrowsinessDrive"];
 			std::string detectionTime = jsonResp["detectionTime"];
-
-			std::cout << "AI 진단 성공 - 졸음 운전 여부: " << (isDrowsy ? "예" : "아니오")
-								<< ", 감지 시각: " << detectionTime << std::endl;
-
-			return isDrowsy;
+			std::cout << "AI 진단 성공 - 졸음 여부: " << (isDrowsy ? "예" : "아니오") << std::endl;
+			callback(true, isDrowsy, "AI 진단 성공, 감지 시각: " + detectionTime);
 		} else {
 			const auto& err = jsonResp["error"];
-			std::cerr << "AI 서버 오류 - 코드: " << err["code"] << ", 메시지: " << err["message"]
-								<< ", 메서드: " << err["method"] << ", 상세: " << err["detail_message"]
-								<< std::endl;
-			return false;
+			std::cerr << "AI 서버 오류 - 메시지: " << err["message"] << std::endl;
+			callback(false, false, "AI 서버 오류: " + std::string(err["message"]));
 		}
 	} catch (const std::exception& e) {
 		std::cerr << "JSON 파싱 오류: " << e.what() << std::endl;
-		return false;
+		callback(false, false, "JSON 파싱 오류: " + std::string(e.what()));
 	}
 }
 

--- a/src/Speaker.cpp
+++ b/src/Speaker.cpp
@@ -11,6 +11,8 @@ Speaker::Speaker(const std::string& soundFilePath, int vol)
 Speaker::~Speaker() {}
 
 void Speaker::initialize() {
+	std::cout << "스피커 초기화 중..." << std::endl;
+
 	// VLC 플레이어 설치 확인
 	int result = system("which cvlc > /dev/null 2>&1");
 
@@ -30,8 +32,6 @@ void Speaker::initialize() {
 		updateDeviceStatus(2, true);	// 스피커는 인덱스 2
 		std::cout << "Speaker initialized successfully with VLC player" << std::endl;
 	}
-
-	sendDeviceStatus();
 }
 
 void Speaker::setAlert(const std::string& soundFile, int vol) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,7 +28,7 @@ int main(int argc, char* argv[]) {
 
 	// 환경 변수 설정 로드
 	Utils envLoader;
-	envLoader.loadEnvFile(".env");
+	envLoader.loadEnvFile("../.env");
 
 	// 장치 ID 설정 (환경 변수 또는 기본값)
 	std::string deviceUID = "rasp-0001";


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 연결해 주세요.  

- Closed #33 

## 📝 작업 내용

> 이번 PR에서 어떤 작업을 했는지 간단히 작성해 주세요.

- 라즈베리파이에서 컴파일을 완료했습니다. 
- Python GIL 문제 해결했습니다.
- 기존에 `build` 파일 밑으로 경로가 지정되어 있던 파일들의 로드 경로를 프로젝트 폴더 아래로 수정했습니다.
- 통신 로직 비동기 변경, timeout 추가했습니다.

현재 `AI 진단 요청 -> Timeout 후 로컬 진단 -> 경고 알람 출력`까지 정상 작동 확인되었습니다.
```
AI Server 진단 요청하는 파이 UID : woierdsf5564 및 요청 시각 : 20250528_110955
Device 0 status updated to: connected
눈 감음 상태: 감김
Device 0 status updated to: connected
눈 감음 상태: 감김
Device 0 status updated to: connected
눈 감음 상태: 감김
Device 0 status updated to: connected
눈 감음 상태: 감김
Device 0 status updated to: connected
눈 감음 상태: 감김
Device 0 status updated to: connected
통신 오류: Connection timed out after 2000 milliseconds
AI 서버 진단 실패: 통신 오류: Connection timed out after 2000 milliseconds
로컬 알고리즘으로 진단을 실시합니다.
Detected sleepiness: 48 consecutive closed-eye frames.
***** 졸음 감지! 알람 작동 *****
```

#30 에서 전체 프로그램 로직 개선을 이어서 할 예정입니다.



### 📸 스크린샷 (선택)

> UI 변경사항이 있다면 캡처해서 첨부해 주세요.

## 💬 리뷰 요청사항 (선택)

> 리뷰어가 중점적으로 봐줬으면 하는 부분이 있다면 적어 주세요.  
> 예: `메서드 XXX의 네이밍`을 좀 더 의미 있게 바꾸고 싶은데 좋은 아이디어가 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 장치 상태를 중앙에서 관리하는 전역 싱글턴 관리자가 도입되어, 각 장치의 연결 상태를 통합적으로 관리하고 백엔드로 전송할 수 있게 되었습니다.

- **기능 개선**
    - 장치 상태 업데이트 및 조회가 각 장치별 개별 관리에서 중앙 집중 관리 방식으로 변경되었습니다.
    - 졸음 감지 요청 및 AI 진단이 비동기 콜백 기반으로 개선되어, 결과와 메시지를 콜백으로 받을 수 있습니다.
    - 장치 초기화 및 진단 과정에서 예외 처리와 로그 출력이 강화되었습니다.
    - 환경설정 파일(.env)과 얼굴 랜드마크 모델 파일의 경로가 변경되었습니다.
    - 가속도 센서, 카메라, 스피커 초기화 시 상태 메시지 출력이 추가되었습니다.

- **버그 수정**
    - 장치 초기화 시 상태 전송 호출이 중복되지 않도록 수정되었습니다.

- **스타일**
    - 일부 헤더 파일의 인덴트 및 include 순서가 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->