### PR TITLE
[Fix] 영상 저장 경로 문제 해결 (#35)

### DIFF
--- a/include/FirmwareManager.h
+++ b/include/FirmwareManager.h
@@ -48,6 +48,9 @@ private:
 	std::thread mainThread;
 	std::mutex detectionMutex;
 
+	// 이전 졸음 상태
+	bool previousSleepy = false;
+
 	// 내부 메서드
 	void mainLoop();
 	bool processSingleFrame();

--- a/include/FirmwareManager.h
+++ b/include/FirmwareManager.h
@@ -51,6 +51,9 @@ private:
 	// 이전 졸음 상태
 	bool previousSleepy = false;
 
+	// 졸음 진단 폴더 경로 저장 스택 (DB 스레드 모니터링용)
+	std::stack<std::string> sleepImgPathStack;
+
 	// 내부 메서드
 	void mainLoop();
 	bool processSingleFrame();

--- a/include/Utils.h
+++ b/include/Utils.h
@@ -3,7 +3,6 @@
 
 #include <cstdlib>
 #include <opencv2/opencv.hpp>
-#include <queue>
 #include <string>
 
 void setEnvVar(const std::string& key, const std::string& value);
@@ -24,7 +23,8 @@ public:
 
 	std::vector<cv::Mat> loadFramesFromRecentFolder(const std::string& timeStamp);
 
-	std::vector<cv::Mat> loadFramesFromFolder(const std::string& folderPath);
+	std::vector<std::pair<std::string, std::string>> getRecentFramePathsAndNames(
+			const std::string& timeStamp);
 
 	std::string createSleepinessDir(const std::string& timeStamp);
 
@@ -35,8 +35,9 @@ public:
 	const int MAX_SLEEPINESS_EVIDENCE_COUNT = 60;
 	bool IsSavingSleepinessEvidence = false;
 
-private:
 	std::string saveDirectory;
+
+private:
 	std::string recentFolder;
 	std::string sleepFolder;
 };

--- a/include/Utils.h
+++ b/include/Utils.h
@@ -11,28 +11,35 @@ void setEnvVar(const std::string& key, const std::string& value);
 
 class Utils {
 public:
-    Utils(const std::string& saveDirectory = "./frames");
+	Utils(const std::string& saveDirectory = "./frames");
 
-    bool saveFrame(const cv::Mat& frame, const std::string& path, const std::string& name);
+	bool saveFrame(const cv::Mat& frame, const std::string& path, const std::string& name);
 
-    bool saveFrameToCurrentFrameFolder(const cv::Mat& frame, const std::string& name);
+	bool saveFrameToCurrentFrameFolder(const cv::Mat& frame, const std::string& name);
 
-    bool saveFrameToSleepinessFolder(const cv::Mat& frame, const std::string& name);
+	bool saveFrameToSleepinessFolder(const cv::Mat& frame, const std::string& name);
 
-    bool removeFolder(const std::string& path);
+	bool removeSleepinessEvidenceFolder() { return removeFolder(sleepFolder); }
+
+	bool removeFolder(const std::string& path);
+
+	std::vector<cv::Mat> loadFramesFromRecentFolder(const std::string& timeStamp);
 
     std::vector<cv::Mat> loadFramesFromRecentFolder();
 
-    std::vector<cv::Mat> loadFramesFromFolder(const std::string& folderPath);
+	std::string createSleepinessDir(const std::string& timeStamp);
 
-    std::string createSleepinessDir(const std::string& timeStamp);
+	void loadEnvFile(const std::string& filename);
 
-    void loadEnvFile(const std::string& filename);
+	// 졸음 근거 영상 저장
+	int sleepinessEvidenceCount = 0;
+	const int MAX_SLEEPINESS_EVIDENCE_COUNT = 60;
+	bool IsSavingSleepinessEvidence = false;
 
 private:
-    std::string saveDirectory;
-    std::string recentFolder;
-    std::string sleepFolder;
+	std::string saveDirectory;
+	std::string recentFolder;
+	std::string sleepFolder;
 };
 
 #endif

--- a/include/Utils.h
+++ b/include/Utils.h
@@ -1,10 +1,9 @@
 #ifndef UTILS_H
 #define UTILS_H
 
-#include <string>
-#include <opencv2/opencv.hpp>
-
 #include <cstdlib>
+#include <opencv2/opencv.hpp>
+#include <queue>
 #include <string>
 
 void setEnvVar(const std::string& key, const std::string& value);
@@ -25,7 +24,7 @@ public:
 
 	std::vector<cv::Mat> loadFramesFromRecentFolder(const std::string& timeStamp);
 
-    std::vector<cv::Mat> loadFramesFromRecentFolder();
+	std::vector<cv::Mat> loadFramesFromFolder(const std::string& folderPath);
 
 	std::string createSleepinessDir(const std::string& timeStamp);
 

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -76,6 +76,10 @@ cv::Mat Camera::captureFrame() {
 }
 
 void Camera::setCameraStatus(bool status) {
+	bool currStatus = getCameraStatus();
+	if (currStatus == status) {
+		return;	 // 상태가 변경되지 않았으면 아무 작업도 하지 않음
+	}
 	updateDeviceStatus(0, status);	// Camera is index 0
 }
 

--- a/src/EyeClosureQueueManagement.cpp
+++ b/src/EyeClosureQueueManagement.cpp
@@ -28,35 +28,26 @@ void EyeClosureQueueManagement::saveEyeClosureStatus(bool eyeClosed) {
 }
 
 bool EyeClosureQueueManagement::detectSleepiness() {
-	// 덱의 데이터가 CONSECUTIVE_FRAMES_FOR_SLEEPINESS보다 적으면 졸음이 아님
 	if (eyeClosureDeque.size() < CONSECUTIVE_FRAMES_FOR_SLEEPINESS) {
-		std::cout << "Deque size (" << eyeClosureDeque.size()
-							<< ") is less than required consecutive frames (" << CONSECUTIVE_FRAMES_FOR_SLEEPINESS
-							<< ") for sleepiness detection." << std::endl;
 		return false;
 	}
 
-	// 가장 최근 프레임부터 역순으로 연속된 눈 감음 검사
-	int consecutiveClosedCount = 0;
+	int consecutiveClosedFrames = 0;
+	int maxConsecutiveClosedFrames = 0;
 
-	// 덱을 반복하면서 연속된 눈 감음 상태 검사
-	for (int i = eyeClosureDeque.size() - 1; i >= 0; i--) {
-		if (eyeClosureDeque[i]) {
-			consecutiveClosedCount++;
-
-			// 연속된 눈 감음 프레임이 기준치에 도달하면 졸음으로 판단
-			if (consecutiveClosedCount >= CONSECUTIVE_FRAMES_FOR_SLEEPINESS) {
-				std::cout << "Detected sleepiness: " << consecutiveClosedCount
-									<< " consecutive closed-eye frames." << std::endl;
-				return true;
-			}
-		} else {
-			// 눈 감음이 연속되지 않으면 카운트 리셋
-			consecutiveClosedCount = 0;
+	// deque의 뒤에서부터 앞으로 순회하면서 현재 연속된 감김 프레임 수를 계산
+	for (auto it = eyeClosureDeque.rbegin(); it != eyeClosureDeque.rend(); ++it) {
+		if (*it) {	// 눈이 감긴 상태
+			consecutiveClosedFrames++;
+			maxConsecutiveClosedFrames = std::max(maxConsecutiveClosedFrames, consecutiveClosedFrames);
+		} else {	// 눈이 열린 상태
+			break;	// 연속성이 깨졌으므로 중단
 		}
 	}
 
-	std::cout << "No sleepiness detected. Maximum consecutive closed-eye frames: "
-						<< consecutiveClosedCount << std::endl;
-	return false;
+	std::cout << "Current consecutive closed frames from end: " << consecutiveClosedFrames
+						<< std::endl;
+
+	// 현재 시점에서 연속으로 감긴 프레임이 임계값 이상인지 확인
+	return consecutiveClosedFrames >= CONSECUTIVE_FRAMES_FOR_SLEEPINESS;
 }

--- a/src/FirmwareManager.cpp
+++ b/src/FirmwareManager.cpp
@@ -474,11 +474,6 @@ void FirmwareManager::handleSleepinessDetected(const std::string& timestamp) {
 	std::string sleepDir = utils->createSleepinessDir(timestamp);
 	std::cout << "졸음 영상 저장 경로: " << sleepDir << std::endl;
 
-	// 폴더 생성 될때까지 잠시 대기
-	std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-	std::cout << "폴더 생성 요청 완료" << std::endl;
-
 	// 3. 진단 시점부터 앞 2.5초 프레임 가져오기
 	std::vector<cv::Mat> recentFrames = utils->loadFramesFromRecentFolder(timestamp);
 

--- a/src/FirmwareManager.cpp
+++ b/src/FirmwareManager.cpp
@@ -239,7 +239,6 @@ void FirmwareManager::mainLoop() {
 			if (frameCycle >= 24) {
 				frameCycle = 0;
 				requestDiagnosis();
-				diagnosticCycle++;
 			}
 		} else {
 			// CPU 점유율 감소를 위해 짧은 시간 대기
@@ -418,12 +417,15 @@ void FirmwareManager::requestDiagnosis() {
 						std::cout << "로컬 알고리즘으로 진단을 실시합니다." << std::endl;
 						std::lock_guard<std::mutex> lock(detectionMutex);
 						finalSleepy = sleepinessDetector->getLocalDetection(*eyeClosureQueue);
+						std::cout << "로컬 진단 호출 사이클" << diagnosticCycle << ": "
+											<< (finalSleepy ? "졸음 감지됨" : "졸음 아님") << std::endl;
 					}
 
 					if (finalSleepy) {
 						std::lock_guard<std::mutex> lock(detectionMutex);
 						handleSleepinessDetected(timestamp);
 					}
+					diagnosticCycle++;
 				});
 	}).detach();
 }

--- a/src/FirmwareManager.cpp
+++ b/src/FirmwareManager.cpp
@@ -374,7 +374,11 @@ bool FirmwareManager::processSingleFrame() {
 	std::string timestamp = ss.str();
 
 	// 프레임 저장
-	utils->saveFrameToCurrentFrameFolder(resizedFrame, timestamp + ".jpg");
+	bool result = utils->saveFrameToCurrentFrameFolder(resizedFrame, timestamp + ".jpg");
+	if (!result) {
+		std::cerr << "Error saving frame to current folder" << std::endl;
+		return false;
+	}
 
 	if (utils->IsSavingSleepinessEvidence) {
 		// 졸음 근거 영상 저장
@@ -441,10 +445,10 @@ void FirmwareManager::requestDiagnosis() {
 
 						// 스택에 저장된 졸음 근거 영상 폴더를 전부 DB 전송 스레드에 추가
 						while (!sleepImgPathStack.empty()) {
-							std::string sleepDir = sleepImgPathStack.top();
+							std::string sleepDir = utils->saveDirectory + sleepImgPathStack.top();
 							sleepImgPathStack.pop();
 
-							auto dbThread = std::make_shared<DBThread>(deviceUID, sleepDir, threadMonitor);
+							auto dbThread = std::make_shared<DBThread>(deviceUID, sleepDir, threadMonitor.get());
 							threadMonitor->addDBThread(dbThread);
 						}
 						threadMonitor->setIsDBThreadRunning(true);

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1,117 +1,122 @@
 #include "../include/Utils.h"
+
 #include <chrono>
 #include <ctime>
-#include <iomanip>
-#include <sstream>
 #include <filesystem>
 #include <fstream>
+#include <iomanip>
+#include <sstream>
 namespace fs = std::filesystem;
 
 void setEnvVar(const std::string& key, const std::string& value) {
 #ifdef _WIN32
-    _putenv_s(key.c_str(), value.c_str());
+	_putenv_s(key.c_str(), value.c_str());
 #else
-    setenv(key.c_str(), value.c_str(), 1);
+	setenv(key.c_str(), value.c_str(), 1);
 #endif
 }
 
-Utils::Utils(const std::string& saveDirectory) 
-    : saveDirectory(saveDirectory), recentFolder("/recent"), sleepFolder("")
-{
-    if (!std::filesystem::exists(saveDirectory)) {
-        std::filesystem::create_directories(saveDirectory);
-    }
+Utils::Utils(const std::string& saveDirectory)
+		: saveDirectory(saveDirectory), recentFolder("/recent"), sleepFolder("") {
+	if (!std::filesystem::exists(saveDirectory)) {
+		std::filesystem::create_directories(saveDirectory);
+	}
 
-    if (!std::filesystem::exists(saveDirectory+recentFolder)) {
-        std::filesystem::create_directories(saveDirectory+recentFolder);
-    }
+	if (!std::filesystem::exists(saveDirectory + recentFolder)) {
+		std::filesystem::create_directories(saveDirectory + recentFolder);
+	}
 }
 
 bool Utils::saveFrame(const cv::Mat& frame, const std::string& path, const std::string& name) {
-    if (frame.empty()) {
-        std::cerr << "Error: Empty frame, cannot save." << std::endl;
-        return false;
-    }
+	if (frame.empty()) {
+		std::cerr << "Error: Empty frame, cannot save." << std::endl;
+		return false;
+	}
 
-    if (!std::filesystem::exists(path)) {
-        std::filesystem::create_directories(path);
-    }
-    return cv::imwrite(path+"/"+name, frame);
+	if (!std::filesystem::exists(path)) {
+		std::filesystem::create_directories(path);
+	}
+	return cv::imwrite(path + "/" + name, frame);
 }
 
-bool Utils::saveFrameToCurrentFrameFolder(const cv::Mat& frame, const std::string& name){
-    if(sleepFolder.size() == 0) return false;
-    return saveFrame(frame, saveDirectory+sleepFolder, name);
+bool Utils::saveFrameToCurrentFrameFolder(const cv::Mat& frame, const std::string& name) {
+	if (sleepFolder.size() == 0) return false;
+	return saveFrame(frame, saveDirectory + recentFolder, name);
 }
 
-bool Utils::saveFrameToSleepinessFolder(const cv::Mat& frame, const std::string& name){
-    return saveFrame(frame, saveDirectory+recentFolder, name);
+bool Utils::saveFrameToSleepinessFolder(const cv::Mat& frame, const std::string& name) {
+	return saveFrame(frame, saveDirectory + sleepFolder, name);
 }
 
-bool Utils::removeFolder(const std::string& folderName){
-    std::string folderPath = saveDirectory + "/" + folderName;
-    try {
-        if (fs::exists(folderPath) && fs::is_directory(folderPath)) {
-            return fs::remove_all(folderPath) > 0;
-        }
-    } catch (const std::exception& e) {
-        std::cerr << "Error removing folder: " << e.what() << std::endl;
-    }
-    return false;
+bool Utils::removeFolder(const std::string& folderName) {
+	std::string folderPath = saveDirectory + "/" + folderName;
+	try {
+		if (fs::exists(folderPath) && fs::is_directory(folderPath)) {
+			return fs::remove_all(folderPath) > 0;
+		}
+	} catch (const std::exception& e) {
+		std::cerr << "Error removing folder: " << e.what() << std::endl;
+	}
+	return false;
 }
 
-std::vector<cv::Mat> Utils::loadFramesFromFolder(const std::string& folderName){
-    std::vector<cv::Mat> frames;
-    std::vector<std::filesystem::directory_entry> entries;
-    for (const auto& entry : std::filesystem::directory_iterator(saveDirectory+"/"+folderName)) {
-        if (entry.path().extension() == ".jpg" || entry.path().extension() == ".png") {
-            entries.push_back(entry);
-        }
-    }
-    std::sort(entries.begin(), entries.end(), [](const auto& a, const auto& b) {
-        return a.path().string() < b.path().string();
-    });
-    for (const auto& entry : entries) {
-        cv::Mat img = cv::imread(entry.path().string());
-        if (!img.empty()) {
-            frames.push_back(img);
-        }
-    }
+std::vector<cv::Mat> Utils::loadFramesFromFolder(const std::string& folderName) {
+	std::vector<cv::Mat> frames;
+	std::vector<std::filesystem::directory_entry> entries;
+	std::string fullPath = saveDirectory + folderName;
+	if (!std::filesystem::exists(fullPath)) {
+		std::cerr << "Directory does not exist: " << fullPath << std::endl;
+		return frames;	// Return empty vector if directory does not exist
+	}
+	for (const auto& entry : std::filesystem::directory_iterator(fullPath)) {
+		if (entry.path().extension() == ".jpg" || entry.path().extension() == ".png") {
+			entries.push_back(entry);
+		}
+	}
+	std::sort(entries.begin(), entries.end(),
+						[](const auto& a, const auto& b) { return a.path().string() < b.path().string(); });
+	for (const auto& entry : entries) {
+		cv::Mat img = cv::imread(entry.path().string());
+		if (!img.empty()) {
+			frames.push_back(img);
+		}
+	}
 
-    return frames;
+	return frames;
 }
 
 std::vector<cv::Mat> Utils::loadFramesFromRecentFolder() {
     return loadFramesFromFolder(recentFolder);
 }
 
-std::string Utils::createSleepinessDir(const std::string& timeStamp){
-    std::string path = "/"+timeStamp;
-    if (!std::filesystem::exists(saveDirectory+path)) {
-        std::filesystem::create_directories(saveDirectory+path);
-    }
+std::string Utils::createSleepinessDir(const std::string& timeStamp) {
+	std::string path = "/" + timeStamp;
+	if (!std::filesystem::exists(saveDirectory + path)) {
+		std::filesystem::create_directories(saveDirectory + path);
+	}
 
-    this->sleepFolder = path;
-    return path;
+	this->sleepFolder = path;
+	this->IsSavingSleepinessEvidence = true;
+	return path;
 }
 
 void Utils::loadEnvFile(const std::string& filename) {
-    std::ifstream file(filename);
-    if (!file.is_open()) {
-        std::cerr << "Could not open .env file\n";
-        return;
-    }
+	std::ifstream file(filename);
+	if (!file.is_open()) {
+		std::cerr << "Could not open .env file\n";
+		return;
+	}
 
-    std::string line;
-    while (std::getline(file, line)) {
-        if (line.empty() || line[0] == '#') continue;
+	std::string line;
+	while (std::getline(file, line)) {
+		if (line.empty() || line[0] == '#') continue;
 
-        size_t delimiterPos = line.find('=');
-        if (delimiterPos == std::string::npos) continue;
+		size_t delimiterPos = line.find('=');
+		if (delimiterPos == std::string::npos) continue;
 
-        std::string key = line.substr(0, delimiterPos);
-        std::string value = line.substr(delimiterPos + 1);
+		std::string key = line.substr(0, delimiterPos);
+		std::string value = line.substr(delimiterPos + 1);
 
-        setEnvVar(key, value); 
-    }
+		setEnvVar(key, value);
+	}
 }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -40,11 +40,11 @@ bool Utils::saveFrame(const cv::Mat& frame, const std::string& path, const std::
 }
 
 bool Utils::saveFrameToCurrentFrameFolder(const cv::Mat& frame, const std::string& name) {
-	if (sleepFolder.size() == 0) return false;
 	return saveFrame(frame, saveDirectory + recentFolder, name);
 }
 
 bool Utils::saveFrameToSleepinessFolder(const cv::Mat& frame, const std::string& name) {
+	if (sleepFolder.size() == 0) return false;
 	return saveFrame(frame, saveDirectory + sleepFolder, name);
 }
 
@@ -63,7 +63,7 @@ bool Utils::removeFolder(const std::string& folderName) {
 std::vector<cv::Mat> Utils::loadFramesFromFolder(const std::string& folderName) {
 	std::vector<cv::Mat> frames;
 	std::vector<std::filesystem::directory_entry> entries;
-	std::string fullPath = saveDirectory + folderName;
+	std::string fullPath = saveDirectory + "/" + folderName;
 	if (!std::filesystem::exists(fullPath)) {
 		std::cerr << "Directory does not exist: " << fullPath << std::endl;
 		return frames;	// Return empty vector if directory does not exist


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 연결해 주세요.  

- Closed #35 

## 📝 작업 내용

> 이번 PR에서 어떤 작업을 했는지 간단히 작성해 주세요.

- 실시간 프레임을 저장하는 `recentFolder`와, 졸음 근거 영상 프레임을 저장하는 `sleepFolder` 경로를 올바르게 수정했습니다.
    - 실시간 프레임은 `'./frames/recent'` 폴더에, 졸음 근거 프레임은 `'./frames/년월일_시분초_밀리초'`(졸음 진단 요청 시간) 폴더에 저장됩니다.
    - 각 프레임 파일명은 '년월일_시분초_밀리초.jpg'(프레임 캡쳐 시간)입니다.
- 졸음 진단 결과 스택을 구현했습니다.
    - 졸음 진단 결과가 `true`일 때 해당 진단의 근거 프레임을 저장할 폴더 경로를 스택에 추가합니다.
    - 연속된 졸음이 나타날 경우 `stack.pop()`을 통해 제거합니다. 
    - 졸음이 `false`가 되면, 스택에 있는 폴더 경로들을 바탕으로 DBThread 인스턴스를 생성해 스레드 모니터링 큐에 추가합니다.
    - 이 스택은 수도코드의 `diagnosisResultStack`에 해당합니다. ([참조 노션](https://www.notion.so/pseudocode-1becd825ecaf8008beddc6ed00fda4d0))



### 📸 스크린샷 (선택)

> UI 변경사항이 있다면 캡처해서 첨부해 주세요.

## 💬 리뷰 요청사항 (선택)

> 리뷰어가 중점적으로 봐줬으면 하는 부분이 있다면 적어 주세요.  
> 예: `메서드 XXX의 네이밍`을 좀 더 의미 있게 바꾸고 싶은데 좋은 아이디어가 있을까요?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 졸음 증거 프레임 저장 및 폴더 관리 기능이 추가되었습니다.
  - 최근 프레임 및 졸음 관련 폴더에서 프레임을 불러오고 저장하는 기능이 확장되었습니다.
  - 졸음 증거 저장 상태 및 최대 저장 개수 제한 기능이 도입되었습니다.
  - 환경 변수 파일(.env) 로드 기능이 추가되었습니다.

- **버그 수정**
  - 카메라 상태 변경 시 중복 업데이트를 방지하도록 개선되었습니다.
  - 프레임 저장 및 불러오기 과정에서 오류 발생 시 적절한 처리가 추가되었습니다.

- **리팩터링**
  - 졸음 감지 로직이 단순화되어 연속된 눈 감김 프레임 계산이 명확해졌습니다.
  - 파일 및 폴더 관리 유틸리티 함수가 일관성 있게 정리되었습니다.
  - 진단 주기 카운터가 비동기 콜백 내로 이동하여 관리가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->